### PR TITLE
feat: abstract fee management and restrict shares creation to Shares

### DIFF
--- a/contracts/fund/fees/FeeManager.sol
+++ b/contracts/fund/fees/FeeManager.sol
@@ -60,7 +60,7 @@ contract FeeManager is IFeeManager, Spoke {
 	/// @dev Anyone can call this function. Useful in case there is little activity
 	/// and a manager wants to cull fees.
 	function settleContinuousFees() external onlyActiveFund {
-		__settleAndPayoutFeesForHook(IFeeManager.FeeHook.Continuous, '');
+		__settleAndPayoutFeesForHook(IFeeManager.FeeHook.Continuous, "");
 	}
 
 	/// @notice Settles all fees for a particular FeeHook, paying out shares wherever possible.

--- a/contracts/fund/fees/IFee.sol
+++ b/contracts/fund/fees/IFee.sol
@@ -1,11 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
+import "./IFeeManager.sol";
+
 /// @title Fee Interface
 /// @author Melon Council DAO <security@meloncoucil.io>
 interface IFee {
-    function feeAmount() external returns (uint256);
-    function identifier() external view returns (uint256);
-    function initializeForUser(uint256, uint256, address) external;
-    function updateState() external;
+	function addFundSettings(bytes calldata) external;
+
+	function feeHook() external view returns (IFeeManager.FeeHook);
+
+	function identifier() external pure returns (string memory);
+
+	function payoutSharesOutstanding() external returns (address, address, uint256);
+
+	function settle(bytes calldata)
+		external
+		returns (
+			address,
+			address,
+			uint256
+		);
 }

--- a/contracts/fund/fees/IFeeManager.sol
+++ b/contracts/fund/fees/IFeeManager.sol
@@ -1,24 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
+pragma experimental ABIEncoderV2;
 
 /// @title FeeManager Interface
 /// @author Melon Council DAO <security@meloncoucil.io>
 interface IFeeManager {
-    function managementFeeAmount() external returns (uint256);
-    function performanceFeeAmount() external returns (uint256);
-    function rewardAllFees() external;
-    function rewardManagementFee() external;
-    function totalFeeAmount() external returns (uint256);
+	enum FeeHook { None, BuyShares, Continuous }
+
+	function enableFees(address[] calldata, bytes[] calldata) external;
+
+	function settleFees(FeeHook, bytes calldata) external;
 }
 
 /// @title FeeManagerFactory Interface
 /// @author Melon Council DAO <security@meloncoucil.io>
 interface IFeeManagerFactory {
-    function createInstance(
-        address,
-        address,
-        address[] calldata,
-        uint[] calldata,
-        uint[] calldata
-    ) external returns (address);
+	function createInstance(address) external returns (address);
 }

--- a/contracts/fund/fees/ManagementFee.sol
+++ b/contracts/fund/fees/ManagementFee.sol
@@ -20,8 +20,8 @@ contract ManagementFee is ContinuousFeeBase {
 		uint256 lastPaid;
 	}
 
-	uint256 public constant RATE_PERIOD = 365 days;
-	uint256 public constant RATE_DIVISOR = 10**18;
+	uint256 constant private RATE_PERIOD = 365 days;
+	uint256 constant private RATE_DIVISOR = 10**18;
 
 	mapping(address => FeeInfo) public feeManagerToFeeInfo;
 

--- a/contracts/fund/fees/ManagementFee.sol
+++ b/contracts/fund/fees/ManagementFee.sol
@@ -2,43 +2,106 @@
 pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "../hub/Spoke.sol";
 import "../shares/Shares.sol";
+import "./utils/ContinuousFeeBase.sol";
 
 /// @title ManagementFee Contract
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Calculates the management fee for a particular fund
-contract ManagementFee {
-    using SafeMath for uint256;
+contract ManagementFee is ContinuousFeeBase {
+	using SafeMath for uint256;
 
-    uint public DIVISOR = 10 ** 18;
+	event FundSettingsAdded(address indexed feeManager, uint256 rate);
 
-    mapping (address => uint) public managementFeeRate;
-    mapping (address => uint) public lastPayoutTime;
+	event PaidOut(address indexed feeManager, uint256 sharesQuantity);
 
-    function feeAmount() external view returns (uint feeInShares) {
-        Shares shares = Shares(IHub(ISpoke(msg.sender).HUB()).shares());
-        if (shares.totalSupply() == 0 || managementFeeRate[msg.sender] == 0) {
-            feeInShares = 0;
-        } else {
-            uint timePassed = block.timestamp.sub(lastPayoutTime[msg.sender]);
-            uint preDilutionFeeShares = shares.totalSupply().mul(managementFeeRate[msg.sender]).mul(timePassed).div(DIVISOR).div(365 days);
-            feeInShares = preDilutionFeeShares.mul(shares.totalSupply()).div(shares.totalSupply().sub(preDilutionFeeShares));
-        }
-        return feeInShares;
-    }
+	struct FeeInfo {
+		uint256 rate;
+		uint256 lastPaid;
+	}
 
-    function initializeForUser(uint feeRate, uint, address) external {
-        require(lastPayoutTime[msg.sender] == 0);
-        managementFeeRate[msg.sender] = feeRate;
-        lastPayoutTime[msg.sender] = block.timestamp;
-    }
+	uint256 public constant RATE_PERIOD = 365 days;
+	uint256 public constant RATE_DIVISOR = 10**18;
 
-    function updateState() external {
-        lastPayoutTime[msg.sender] = block.timestamp;
-    }
+	mapping(address => FeeInfo) public feeManagerToFeeInfo;
 
-    function identifier() external pure returns (uint) {
-        return 0;
-    }
+	constructor(address _registry) public ContinuousFeeBase(_registry) {}
+
+	// EXTERNAL FUNCTIONS
+
+	/// @notice Add the initial fee settings for a fund
+	/// @param _encodedSettings Encoded settings to apply to a fund
+	/// @dev A fund's FeeManager is always the sender
+	/// @dev Only called once, on FeeManager.enableFees()
+	function addFundSettings(bytes calldata _encodedSettings) external override onlyFeeManager {
+		uint256 feeRate = abi.decode(_encodedSettings, (uint256));
+		require(feeRate > 0, "addFundSettings: feeRate must be greater than 0");
+
+		feeManagerToFeeInfo[msg.sender] = FeeInfo({ rate: feeRate, lastPaid: block.timestamp });
+
+		emit FundSettingsAdded(msg.sender, feeRate);
+	}
+
+	/// @notice Provides a constant string identifier for a fee
+	/// @return The identifier string
+	function identifier() external override pure returns (string memory) {
+		return "MANAGEMENT";
+	}
+
+	/// @notice Settle the fee and reconcile shares due
+	/// @return payer_ The account from which the sharesDue will be deducted
+	/// @return payee_ The account to which the sharesDue will be added
+	/// @return sharesDue_ The amount of shares that should be distributed from payer_ to payee_
+	function settle(bytes calldata)
+		external
+		override
+		onlyFeeManager
+		returns (
+			address payer_,
+			address payee_,
+			uint256 sharesDue_
+		)
+	{
+		Hub hub = Hub(Spoke(msg.sender).HUB());
+		Shares shares = Shares(__getShares(address(hub)));
+		uint256 sharesSupply = shares.totalSupply();
+
+		sharesDue_ = __calcSettlementSharesDue(msg.sender, sharesSupply);
+		if (sharesDue_ == 0) {
+			return __emptySharesDueValues();
+		}
+
+		// Settle by minting shares to manager
+		payer_ = address(shares);
+		payee_ = hub.MANAGER();
+
+		// Update fee state for fund
+		feeManagerToFeeInfo[msg.sender].lastPaid = block.timestamp;
+
+		emit PaidOut(msg.sender, sharesDue_);
+	}
+
+	// PRIVATE FUNCTIONS
+
+	/// @dev Helper to calculate the shares due at settlement (including inflation)
+	function __calcSettlementSharesDue(address _feeManager, uint256 _sharesQuantity)
+		private
+		view
+		returns (uint256)
+	{
+		if (_sharesQuantity == 0) {
+			return 0;
+		}
+
+		FeeInfo memory feeInfo = feeManagerToFeeInfo[_feeManager];
+		uint256 timeSinceLastPaid = block.timestamp.sub(feeInfo.lastPaid);
+		if (timeSinceLastPaid == 0) {
+			return 0;
+		}
+
+		uint256 yearlySharesDueRate = _sharesQuantity.mul(feeInfo.rate).div(RATE_DIVISOR);
+		uint256 rawSharesDue = yearlySharesDueRate.mul(timeSinceLastPaid).div(RATE_PERIOD);
+
+		return __calcSharesDueWithInflation(rawSharesDue, _sharesQuantity);
+	}
 }

--- a/contracts/fund/fees/PerformanceFee.sol
+++ b/contracts/fund/fees/PerformanceFee.sol
@@ -34,7 +34,7 @@ contract PerformanceFee is ContinuousFeeBase {
 		uint256 lastSharePrice;
 	}
 
-	uint256 constant RATE_DIVISOR = 10**18;
+	uint256 constant private RATE_DIVISOR = 10**18;
 
 	mapping(address => FeeInfo) public feeManagerToFeeInfo;
 

--- a/contracts/fund/fees/PerformanceFee.sol
+++ b/contracts/fund/fees/PerformanceFee.sol
@@ -2,86 +2,240 @@
 pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../hub/Spoke.sol";
 import "../shares/Shares.sol";
-import "../vault/Vault.sol";
+import "./utils/ContinuousFeeBase.sol";
 
 /// @title PerformanceFee Contract
 /// @author Melon Council DAO <security@meloncoucil.io>
-/// @notice Calculates the performace fee for a particular fund
-contract PerformanceFee {
-    using SafeMath for uint256;
+/// @notice Calculates the performance fee for a particular fund
+contract PerformanceFee is ContinuousFeeBase {
+	using SafeMath for uint256;
+	using SignedSafeMath for int256;
 
-    event HighWaterMarkUpdate(address indexed feeManager, uint indexed hwm);
+	event FundSettingsAdded(address indexed feeManager, uint256 rate, uint256 period);
 
-    uint public constant DIVISOR = 10 ** 18;
-    uint public constant REDEEM_WINDOW = 1 weeks;
+	event PaidOut(address indexed feeManager, uint256 sharesDue);
 
-    mapping(address => uint) public highWaterMark;
-    mapping(address => uint) public lastPayoutTime;
-    mapping(address => uint) public initializeTime;
-    mapping(address => uint) public performanceFeeRate;
-    mapping(address => uint) public performanceFeePeriod;
+	event PerformanceUpdated(
+		address indexed feeManager,
+		uint256 prevSharePrice,
+		uint256 currentSharePrice,
+		int256 sharesOutstandingDiff
+	);
 
-    /// @notice Sets initial state of the fee for a user
-    function initializeForUser(uint feeRate, uint feePeriod, address denominationAsset) external {
-        require(lastPayoutTime[msg.sender] == 0, "Already initialized");
-        performanceFeeRate[msg.sender] = feeRate;
-        performanceFeePeriod[msg.sender] = feePeriod;
-        highWaterMark[msg.sender] = 10 ** uint(ERC20(denominationAsset).decimals());
-        lastPayoutTime[msg.sender] = block.timestamp;
-        initializeTime[msg.sender] = block.timestamp;
-    }
+	struct FeeInfo {
+		uint256 rate;
+		uint256 period;
+		uint256 created;
+		uint256 lastPaid;
+		uint256 lastSharePrice;
+	}
 
-    /// @notice Assumes management fee is zero
-    function feeAmount() external returns (uint feeInShares) {
-        Shares shares = Shares(IHub(Spoke(msg.sender).HUB()).shares());
-        uint sharesSupply = shares.totalSupply();
-        if (sharesSupply == 0) return 0;
+	uint256 constant RATE_DIVISOR = 10**18;
 
-        uint gav = shares.calcGav();
-        uint gavPerShare = gav.mul(10 ** uint256(shares.decimals())).div(sharesSupply);
-        if (gavPerShare <= highWaterMark[msg.sender]) return 0;
+	mapping(address => FeeInfo) public feeManagerToFeeInfo;
 
-        uint sharePriceGain = gavPerShare.sub(highWaterMark[msg.sender]);
-        uint totalGain = sharePriceGain.mul(sharesSupply).div(DIVISOR);
-        uint feeInAsset = totalGain.mul(performanceFeeRate[msg.sender]).div(DIVISOR);
-        uint preDilutionFee = sharesSupply.mul(feeInAsset).div(gav);
+	constructor(address _registry) public ContinuousFeeBase(_registry) {}
 
-        return preDilutionFee.mul(sharesSupply).div(sharesSupply.sub(preDilutionFee));
-    }
+	// EXTERNAL FUNCTIONS
 
-    function canUpdate(address _who) public view returns (bool) {
-        uint timeSinceInit = uint256(block.timestamp).sub(initializeTime[_who]);
-        uint secondsSinceLastPeriod = timeSinceInit.mod(performanceFeePeriod[_who]);
-        uint lastPeriodEnd = uint256(block.timestamp).sub(secondsSinceLastPeriod);
-        return (
-            secondsSinceLastPeriod <= REDEEM_WINDOW &&
-            lastPayoutTime[_who] < lastPeriodEnd
-        );
-    }
+	/// @notice Add the initial fee settings for a fund
+	/// @param _encodedSettings Encoded settings to apply to a fund
+	/// @dev A fund's FeeManager is always the sender
+	/// @dev Only called once, on FeeManager.enableFees()
+	function addFundSettings(bytes calldata _encodedSettings) external override onlyFeeManager {
+		(uint256 feeRate, uint256 feePeriod) = abi.decode(_encodedSettings, (uint256, uint256));
+		require(feeRate > 0, "addFundSettings: feeRate must be greater than 0");
+		require(feePeriod > 0, "addFundSettings: feePeriod must be greater than 0");
 
-    /// @notice Assumes management fee is zero
-    function updateState() external {
-        require(lastPayoutTime[msg.sender] != 0, "Not initialized");
-        require(
-            canUpdate(msg.sender),
-            "Not within a update window or already updated this period"
-        );
-        Shares shares = Shares(IHub(Spoke(msg.sender).HUB()).shares());
+		feeManagerToFeeInfo[msg.sender] = FeeInfo({
+			rate: feeRate,
+			period: feePeriod,
+			created: block.timestamp,
+			lastPaid: block.timestamp,
+			lastSharePrice: Shares(__getShares()).calcSharePrice()
+		});
 
-        uint currentGavPerShare = shares.calcGav().mul(10 ** uint256(shares.decimals())).div(shares.totalSupply());
-        require(
-            currentGavPerShare > highWaterMark[msg.sender],
-            "Current share price does not pass high water mark"
-        );
-        lastPayoutTime[msg.sender] = block.timestamp;
-        highWaterMark[msg.sender] = currentGavPerShare;
-        emit HighWaterMarkUpdate(msg.sender, currentGavPerShare);
-    }
+		emit FundSettingsAdded(msg.sender, feeRate, feePeriod);
+	}
 
-    function identifier() external pure returns (uint) {
-        return 1;
-    }
+	/// @notice Provides a constant string identifier for a fee
+	/// @return The identifier string
+	function identifier() external override pure returns (string memory) {
+		return "PERFORMANCE";
+	}
+
+	/// @notice Payout shares outstanding to the fund manager
+	/// @return payer_ The account from which the sharesDue will be deducted
+	/// @return payee_ The account to which the sharesDue will be added
+	/// @return sharesDue_ The amount of shares that should be distributed from payer_ to payee_
+	function payoutSharesOutstanding()
+		external
+		override
+		onlyFeeManager
+		returns (
+			address payer_,
+			address payee_,
+			uint256 sharesDue_
+		)
+	{
+		if (!payoutAllowed(msg.sender)) {
+			return __emptySharesDueValues();
+		}
+
+		Hub hub = Hub(Spoke(msg.sender).HUB());
+		Shares shares = Shares(__getShares(address(hub)));
+
+		sharesDue_ = shares.balanceOf(address(this));
+		if (sharesDue_ == 0) {
+			return __emptySharesDueValues();
+		}
+
+		// Distribute shares outstanding from fee custody to fund manager
+		payer_ = address(this);
+		payee_ = hub.MANAGER();
+
+		feeManagerToFeeInfo[msg.sender].lastPaid = block.timestamp;
+
+		emit PaidOut(msg.sender, sharesDue_);
+	}
+
+	/// @notice Settle the fee and reconcile shares due
+	/// @return payer_ The account from which the sharesDue will be deducted
+	/// @return payee_ The account to which the sharesDue will be added
+	/// @return sharesDue_ The amount of shares that should be distributed from payer_ to payee_
+	function settle(bytes calldata)
+		external
+		override
+		onlyFeeManager
+		returns (
+			address payer_,
+			address payee_,
+			uint256 sharesDue_
+		)
+	{
+		Shares shares = Shares(__getShares());
+		uint256 sharesSupply = shares.totalSupply();
+		if (sharesSupply == 0) {
+			return __emptySharesDueValues();
+		}
+
+		int256 settlementSharesDue = __settleAndUpdatePerformance(
+			msg.sender,
+			shares,
+			sharesSupply
+		);
+		if (settlementSharesDue == 0) {
+			return __emptySharesDueValues();
+		}
+
+		// Settle by minting shares outstanding to the fee for custody
+		if (settlementSharesDue > 0) {
+			payer_ = address(shares);
+			payee_ = address(this);
+			sharesDue_ = uint256(settlementSharesDue);
+		}
+		// Settle by burning from shares outstanding from the fee's custody
+		else {
+			payer_ = address(this);
+			payee_ = address(shares);
+			sharesDue_ = uint256(-settlementSharesDue);
+		}		
+	}
+
+	// PUBLIC FUNCTIONS
+
+	/// @notice Checks whether the outstanding shares can be paid out
+	/// @param _feeManager The feeManager for which to check whether the fee is due
+	/// @return True if the fee payment is due
+	/// @dev Payout is allowed if fees have not yet been settled in an elapsed redemption period
+	function payoutAllowed(address _feeManager) public view returns (bool) {
+		FeeInfo memory feeInfo = feeManagerToFeeInfo[_feeManager];
+
+		uint256 timeSinceCreated = block.timestamp.sub(feeInfo.created);
+		uint256 timeSinceRedeemWindowStart = timeSinceCreated % feeInfo.period;
+		uint256 redeemWindowStart = block.timestamp.sub(timeSinceRedeemWindowStart);
+		return feeInfo.lastPaid < redeemWindowStart;
+	}
+
+	// PRIVATE FUNCTIONS
+
+	/// @dev Helper to calculate the sharesDue during settlement
+	function __calcSettlementSharesDue(
+		address _feeManager,
+		uint256 _sharesUnit,
+		uint256 _sharesSupply,
+		uint256 _currentGav,
+		uint256 _prevSharePrice
+	)
+		private
+		view
+		returns (int256)
+	{
+		// Calculate fee due in gav
+		// _sharesSupply and Gav could have likely fluctuated between calls, so this is an estimated amount
+		uint256 estPrevGav = _prevSharePrice.mul(_sharesSupply).div(_sharesUnit);
+		int256 estGavDiff = int256(_currentGav).sub(int256(estPrevGav));
+		int256 feeDueInGav = estGavDiff.mul(int256(feeManagerToFeeInfo[_feeManager].rate)).div(int256(RATE_DIVISOR));
+
+		// Calculate raw fee due in shares
+		int256 rawSharesDue = feeDueInGav.mul(int256(_sharesSupply)).div(int256(_currentGav));
+
+		// Calculate shares due with inflation or deflation
+		if (rawSharesDue == 0) {
+			return 0;
+		}
+
+		if (rawSharesDue > 0) {
+			return int256(__calcSharesDueWithInflation(uint256(rawSharesDue), _sharesSupply));
+		}
+		else {
+			// TODO: This is where we can implement a separate formula for deflating on negative shares owed.
+			// If we use the same formula, change the names-spacing to indicate signed int math.
+			return __calcSharesDueWithInflation(rawSharesDue, int256(_sharesSupply));
+		}
+	}
+
+	/// @dev Helper to settle fee and update performance state
+	function __settleAndUpdatePerformance(
+		address _feeManager,
+		Shares _shares,
+		uint256 _sharesSupply
+	)
+		private
+		returns (int256 sharesDue_)
+	{
+		uint256 sharesUnit = 10**uint256(_shares.decimals());
+		uint256 gav = _shares.calcGav();
+		uint256 prevSharePrice = feeManagerToFeeInfo[_feeManager].lastSharePrice;
+
+		// Calculate shares due
+		sharesDue_ = __calcSettlementSharesDue(
+			_feeManager,
+			sharesUnit,
+			_sharesSupply,
+			gav,
+			prevSharePrice
+		);
+		if (sharesDue_ == 0) {
+			return 0;
+		}
+
+		// Update performance state
+		uint256 nextSharePrice;
+		// TODO: Revisit this. If a fund has negative shares owed, then the share price will increase,
+		// so do not update the lastSharePrice? Calculate based on the new gav per share?
+		if (sharesDue_ < 0) {
+			nextSharePrice = prevSharePrice;
+		}
+		else {
+			nextSharePrice = gav.mul(sharesUnit).div(_sharesSupply);
+			feeManagerToFeeInfo[_feeManager].lastSharePrice = nextSharePrice;
+		}
+
+		emit PerformanceUpdated(_feeManager, prevSharePrice, nextSharePrice, sharesDue_);
+	}
 }

--- a/contracts/fund/fees/utils/ContinuousFeeBase.sol
+++ b/contracts/fund/fees/utils/ContinuousFeeBase.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
+import "./FeeBase.sol";
+
+/// @title ContinuousFeeBase Contract
+/// @author Melon Council DAO <security@meloncoucil.io>
+/// @notice Abstract base contract for Continuous fees
+abstract contract ContinuousFeeBase is FeeBase {
+	using SafeMath for uint256;
+	using SignedSafeMath for int256;
+
+	constructor(address _registry) public FeeBase(_registry) {}
+
+	/// @notice Provides a constant string identifier for a policy
+	function feeHook() external override view returns (IFeeManager.FeeHook) {
+		return IFeeManager.FeeHook.Continuous;
+	}
+
+	/// @dev Helper to calculate shares due, taking deflation into account (negative shares due)
+	function __calcSharesDueWithInflation(int256 _rawSharesDue, int256 _sharesSupply)
+		internal
+		pure
+		returns (int256)
+	{
+		if (_rawSharesDue == 0 || _sharesSupply == 0) {
+			return 0;
+		}
+		return _rawSharesDue.mul(_sharesSupply).div(_sharesSupply.sub(_rawSharesDue));
+	}
+
+	/// @dev Helper to calculate shares due, taking inflation into account (positive shares due)
+	function __calcSharesDueWithInflation(uint256 _rawSharesDue, uint256 _sharesSupply)
+		internal
+		pure
+		returns (uint256)
+	{
+		if (_rawSharesDue == 0 || _sharesSupply == 0) {
+			return 0;
+		}
+		return _rawSharesDue.mul(_sharesSupply).div(_sharesSupply.sub(_rawSharesDue));
+	}
+}

--- a/contracts/fund/fees/utils/FeeBase.sol
+++ b/contracts/fund/fees/utils/FeeBase.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+import "../../../registry/Registry.sol";
+import "../../hub/Hub.sol";
+import "../../hub/Spoke.sol";
+import "../../hub/SpokeCallee.sol";
+import "../IFee.sol";
+
+/// @title FeeBase Contract
+/// @author Melon Council DAO <security@meloncoucil.io>
+/// @notice Abstract base contract for fees
+abstract contract FeeBase is IFee, SpokeCallee {
+	address public REGISTRY;
+
+	modifier onlyFeeManager {
+		require(__isFeeManager(msg.sender), "Only FeeManger can make this call");
+		_;
+	}
+
+	constructor(address _registry) public {
+		REGISTRY = _registry;
+	}
+
+	/// @dev Returns empty by default, can be overridden by fee
+	function payoutSharesOutstanding()
+		external
+		override
+		virtual
+		returns (address, address, uint256)
+	{
+		return __emptySharesDueValues();
+	}
+
+	// INTERNAL FUNCTIONS
+
+	/// @dev Helper to return empty values for settlement and payout
+	function __emptySharesDueValues()
+		internal
+		pure
+		returns (address, address, uint256)
+	{
+		return (address(0), address(0), 0);
+	}
+
+	/// @notice Helper to determine whether an address is a valid FeeManager component
+	function __isFeeManager(address _who) internal view returns (bool) {
+		// 1. Is valid Spoke of a Registered fund
+		// 2. Is the fee manager of the registered fund
+		try Spoke(_who).HUB() returns (address hub) {
+			return Registry(REGISTRY).fundIsRegistered(hub) && __getFeeManager(hub) == _who;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/contracts/fund/hub/Hub.sol
+++ b/contracts/fund/hub/Hub.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
+import "../fees/IFeeManager.sol";
 import "./IHub.sol";
 
 /// @title Hub Contract
@@ -23,7 +24,7 @@ contract Hub is IHub {
     string public NAME;
     FundStatus public override status;
 
-    // Infrastruture
+    // Infrastructure
     address public override FUND_FACTORY;
     address public override REGISTRY;
 
@@ -61,7 +62,7 @@ contract Hub is IHub {
     /// @notice Sets the feeManager address for the fund
     /// @param _feeManager The FeeManager component for the fund
     function setFeeManager(address _feeManager) external onlyFundFactory {
-        require(feeManager == address(0), "setFeeManager: feeMangaer is already set");
+        require(feeManager == address(0), "setFeeManager: feeManager is already set");
 
         feeManager = _feeManager;
         emit FeeManagerSet(feeManager);

--- a/contracts/fund/hub/Spoke.sol
+++ b/contracts/fund/hub/Spoke.sol
@@ -19,6 +19,21 @@ abstract contract Spoke is ISpoke, FundRouterMixin {
     // TODO: set as immutable upon solidity upgrade
     address public override HUB;
 
+    modifier onlyActiveFund() {
+        require(IHub(HUB).status() == IHub.FundStatus.Active, "Only an active fund can use this function");
+        _;
+    }
+
+    modifier onlyFeeManager() {
+        require(msg.sender == address(__getFeeManager()), "Only FeeManager can call this function");
+        _;
+    }
+
+    modifier onlyFundFactory() {
+        require(msg.sender == IHub(HUB).FUND_FACTORY(), "Only FundFactory can call this function");
+        _;
+    }
+
     modifier onlyManager() {
         require(msg.sender == IHub(HUB).MANAGER(), "Only the fund manager can call this function");
         _;

--- a/contracts/fund/policies/PolicyManager.sol
+++ b/contracts/fund/policies/PolicyManager.sol
@@ -25,12 +25,8 @@ contract PolicyManager is IPolicyManager, Spoke {
     function enablePolicies(address[] calldata _policies, bytes[] calldata _encodedSettings)
         external
         override
+        onlyFundFactory
     {
-        // Access
-        require(
-            msg.sender == __getHub().FUND_FACTORY(),
-            "Only FundFactory can make this call"
-        );
         // Sanity check
         require(_policies.length > 0, "enablePolicies: _policies cannot be empty");
         require(

--- a/contracts/fund/shares/IShares.sol
+++ b/contracts/fund/shares/IShares.sol
@@ -4,9 +4,10 @@ pragma solidity 0.6.8;
 /// @title Shares Interface
 /// @author Melon Council DAO <security@meloncoucil.io>
 interface IShares {
+    function burn(address, uint256) external;
     function buyShares(address, uint256, uint256) external returns (uint256);
     function DENOMINATION_ASSET() external returns (address);
-    function createFor(address, uint256) external; // TODO: remove when change FeeManager arch
+    function mint(address, uint256) external;
 }
 
 /// @title SharesFactory Interface

--- a/contracts/fund/shares/Shares.sol
+++ b/contracts/fund/shares/Shares.sol
@@ -82,7 +82,7 @@ contract Shares is IShares, Spoke, SharesToken {
         IFeeManager feeManager = __getFeeManager();
 
         // Calculate full shares quantity for investment amount after updating continuous fees
-        feeManager.settleFees(IFeeManager.FeeHook.Continuous, '');
+        feeManager.settleFees(IFeeManager.FeeHook.Continuous, "");
         uint256 sharesQuantity = _investmentAmount.mul(10 ** uint256(ERC20(DENOMINATION_ASSET).decimals())).div(calcSharePrice());
 
         // This is inefficient to mint, and then allow the feeManager to burn/mint to settle the fee,
@@ -192,7 +192,7 @@ contract Shares is IShares, Spoke, SharesToken {
 
         // Attempt to settle fees, but don't allow an error to block redemption
         // This also handles a rejection from onlyActiveFund when the fund is shutdown
-        try __getFeeManager().settleFees(IFeeManager.FeeHook.Continuous, '') {}
+        try __getFeeManager().settleFees(IFeeManager.FeeHook.Continuous, "") {}
         catch {}
 
         // Check the shares quantity against the user's balance after settling fees

--- a/contracts/fund/vault/Vault.sol
+++ b/contracts/fund/vault/Vault.sol
@@ -62,6 +62,7 @@ contract Vault is IVault, Spoke {
     )
         external
         onlyManager
+        onlyActiveFund
     {
         bytes4 selector = bytes4(keccak256(bytes(_methodSignature)));
 

--- a/tests/deployment.ts
+++ b/tests/deployment.ts
@@ -162,11 +162,13 @@ const constructors: ContractConstructors = {
   vaultFactory: (config) => {
     return contracts.VaultFactory.deploy(config.deployer);
   },
-  managementFee: (config) => {
-    return contracts.ManagementFee.deploy(config.deployer);
+  managementFee: async (config, deployment) => {
+    const Registry = await deployment.registry;
+    return contracts.ManagementFee.deploy(config.deployer, Registry);
   },
-  performanceFee: (config) => {
-    return contracts.PerformanceFee.deploy(config.deployer);
+  performanceFee: async (config, deployment) => {
+    const Registry = await deployment.registry;
+    return contracts.PerformanceFee.deploy(config.deployer, Registry);
   },
   assetBlacklist: async (config, deployment) => {
     const Registry = await deployment.registry;

--- a/tests/tests/FeeManager.test.ts
+++ b/tests/tests/FeeManager.test.ts
@@ -1,15 +1,11 @@
 import { BuidlerProvider } from '@crestproject/crestproject';
 import { configureTestDeployment } from '../deployment';
-import {
-    dummyFee,
-    setupFundWithParams,
-  } from '../utils';
-  import { IFee } from '../codegen/IFee';
+import { dummyFee, setupFundWithParams } from '../utils';
+import { IFee } from '../codegen/IFee';
 
 let tx;
 
 async function snapshot(provider: BuidlerProvider) {
-
   const deployment = await configureTestDeployment()(provider);
   const {
     system: { fundFactory, registry },
@@ -20,16 +16,16 @@ async function snapshot(provider: BuidlerProvider) {
   } = deployment;
 
   const mockFee = await IFee.mock(deployer);
-  await mockFee.identifier.returns("MOCK");
+  await mockFee.identifier.returns('MOCK');
   await mockFee.feeHook.returns(2); // Continuous fee
-  await mockFee.addFundSettings.returns("");
+  await mockFee.addFundSettings.returns('');
   await registry.registerFee(mockFee);
 
   const fund = await setupFundWithParams({
     factory: fundFactory,
     manager: deployer,
     denominationAsset: weth,
-    fees: [await dummyFee(mockFee.address)]
+    fees: [await dummyFee(mockFee.address)],
   });
 
   return { ...deployment, fund, mockFee };
@@ -47,10 +43,8 @@ describe('FeeManager', () => {
     // TODO: need to do a mock FeeManager if we want to test the event.
     it('enables only the specified fee', async () => {
       const {
-        fund: {
-          feeManager
-        },
-        mockFee
+        fund: { feeManager },
+        mockFee,
       } = await provider.snapshot(snapshot);
 
       tx = feeManager.feeIsEnabled(mockFee);
@@ -70,25 +64,33 @@ describe('FeeManager', () => {
     it.todo('only calls fees of the specified FeeHook');
     it.todo('only calls fees of the specified FeeHook');
 
-    it.todo('calls Fee.payoutSharesOutstanding even if there are 0 shares due from Fee.settle');
+    it.todo(
+      'calls Fee.payoutSharesOutstanding even if there are 0 shares due from Fee.settle',
+    );
   });
 
   describe('__distributeSharesDue', () => {
     it.todo('returns if the _payer and _payee are the same');
     it.todo('only burns _payer shares if _payee is Shares');
     it.todo('only mints shares to _payee if _payer is Shares');
-    it.todo('burns _payer shares and mints _payee shares if neither _payer nor _payee is Shares');
+    it.todo(
+      'burns _payer shares and mints _payee shares if neither _payer nor _payee is Shares',
+    );
   });
 
   describe('__payoutFeeSharesOutstanding', () => {
     it.todo('calls payoutSharesOutstanding on the Fee');
-    it.todo('does not attempt to distribute fees or emit event if no shares are due');
+    it.todo(
+      'does not attempt to distribute fees or emit event if no shares are due',
+    );
     it.todo('emits FeeSharesOutstandingPaid with correct return values');
   });
 
   describe('__settleFee', () => {
     it.todo('calls settle on the Fee with the proper args');
-    it.todo('does not attempt to distribute fees or emit event if no shares are due');
+    it.todo(
+      'does not attempt to distribute fees or emit event if no shares are due',
+    );
     it.todo('emits FeeSettled with correct return values');
   });
 });

--- a/tests/tests/FeeManager.test.ts
+++ b/tests/tests/FeeManager.test.ts
@@ -1,0 +1,88 @@
+import { BuidlerProvider, randomAddress } from '@crestproject/crestproject';
+import { configureTestDeployment } from '../deployment';
+import * as contracts from '../contracts';
+
+let tx;
+
+async function snapshot(provider: BuidlerProvider) {
+  const deployment = await configureTestDeployment()(provider);
+  const hub = await contracts.Hub.mock(deployment.config.deployer);
+  await hub.REGISTRY.returns(deployment.system.registry);
+  await hub.MANAGER.returns(deployment.config.deployer);
+
+  return { ...deployment, hub };
+}
+
+describe('Shares', () => {
+  describe('constructor', () => {
+    it('cannot set a non-primitive asset as denomination asset', async () => {
+      const {
+        hub,
+        system: { registry },
+        config: { deployer },
+      } = await provider.snapshot(snapshot);
+      const denomination = randomAddress();
+
+      // Should fail, due to the denomination asset not being registered
+      tx = contracts.Shares.deploy(deployer, hub, denomination, 'shares');
+      await expect(tx).rejects.toBeRevertedWith(
+        'Denomination asset must be registered',
+      );
+
+      // Register denomination asset, and it should succeed
+      await registry.registerPrimitive(denomination);
+      tx = contracts.Shares.deploy(deployer, hub, denomination, 'shares');
+      await expect(tx).resolves.toBeInstanceOf(contracts.Shares);
+    });
+
+    it('sets initial storage values', async () => {
+      const {
+        hub,
+        config: {
+          deployer,
+          tokens: { weth },
+        },
+      } = await provider.snapshot(snapshot);
+
+      const name = 'My Shares';
+      const shares = await contracts.Shares.deploy(deployer, hub, weth, name);
+
+      tx = shares.HUB();
+      await expect(tx).resolves.toBe(hub.address);
+
+      tx = shares.DENOMINATION_ASSET();
+      await expect(tx).resolves.toBe(weth.address);
+
+      tx = shares.name();
+      await expect(tx).resolves.toBe(name);
+
+      tx = shares.symbol();
+      await expect(tx).resolves.toBe('MLNF');
+
+      tx = shares.decimals();
+      await expect(tx).resolves.toBe(18);
+    });
+  });
+
+  describe('buyShares', () => {
+    it.todo('can only be called by SharesRequestor');
+
+    it.todo('reverts if _minSharesQuantity is not met');
+
+    it.todo('deducts owed fees');
+
+    it.todo('updates state and emits SharesBought');
+  });
+
+  describe('__redeemShares', () => {
+    it.todo('reverts if a user does not have enough shares');
+
+    it.todo('reverts if the fund has no assets');
+
+    it.todo('reverts with a bad asset transfer function');
+
+    it.todo('deducts owed fees');
+
+    it.todo('updates state and emits SharesBought');
+  });
+});

--- a/tests/tests/Registry.test.ts
+++ b/tests/tests/Registry.test.ts
@@ -1,11 +1,23 @@
 import { utils } from 'ethers';
 import { BuidlerProvider, randomAddress } from '@crestproject/crestproject';
 import { configureTestDeployment } from '../deployment';
+import { IFee } from '../codegen/IFee';
 
 let tx;
 
 async function snapshot(provider: BuidlerProvider) {
-  return configureTestDeployment()(provider);
+  const deployment = await configureTestDeployment()(provider);
+  const {
+    config: {
+      deployer,
+    },
+  } = deployment;
+
+  const mockFee = await IFee.mock(deployer);
+  await mockFee.identifier.returns("MOCK");
+  await mockFee.feeHook.returns(1);
+
+  return { ...deployment, mockFee };
 }
 
 describe('Registry', () => {
@@ -276,45 +288,45 @@ describe('Registry', () => {
   describe('deregisterFee', () => {
     it('can only be called by owner', async () => {
       const {
+        mockFee,
         system: { registry },
         config: {
           accounts: [maliciousUser],
         },
       } = await provider.snapshot(snapshot);
       const disallowed = registry.connect(provider.getSigner(maliciousUser));
-      const fee = randomAddress();
 
-      tx = disallowed.deregisterFee(fee);
+      tx = disallowed.deregisterFee(mockFee);
       await expect(tx).rejects.toBeRevertedWith('caller is not the owner');
     });
 
     it('does not allow unregistered fee', async () => {
       const {
+        mockFee,
         system: { registry },
       } = await provider.snapshot(snapshot);
-      const fee = randomAddress();
 
-      tx = registry.deregisterFee(fee);
+      tx = registry.deregisterFee(mockFee);
       await expect(tx).rejects.toBeRevertedWith('_fee is not registered');
     });
 
     it('fee is removed', async () => {
       const {
+        mockFee,
         system: { registry },
       } = await provider.snapshot(snapshot);
-      const fee = randomAddress();
 
-      tx = registry.registerFee(fee);
+      tx = registry.registerFee(mockFee);
       await expect(tx).resolves.toBeReceipt();
 
-      tx = registry.feeIsRegistered(fee);
+      tx = registry.feeIsRegistered(mockFee);
       await expect(tx).resolves.toBeTruthy();
 
-      tx = registry.deregisterFee(fee);
+      tx = registry.deregisterFee(mockFee);
       await expect(tx).resolves.toBeReceipt();
       await expect(tx).resolves.toHaveEmitted('FeeRemoved');
 
-      tx = registry.feeIsRegistered(fee);
+      tx = registry.feeIsRegistered(mockFee);
       await expect(tx).resolves.toBeFalsy();
     });
 
@@ -324,42 +336,43 @@ describe('Registry', () => {
   describe('registerFee', () => {
     it('can only be called by owner', async () => {
       const {
+        mockFee,
         system: { registry },
         config: {
           accounts: [maliciousUser],
         },
       } = await provider.snapshot(snapshot);
       const disallowed = registry.connect(provider.getSigner(maliciousUser));
-      const fee = randomAddress();
 
-      tx = disallowed.registerFee(fee);
+      tx = disallowed.registerFee(mockFee);
       await expect(tx).rejects.toBeRevertedWith('caller is not the owner');
     });
 
     it('does not allow registered asset', async () => {
       const {
+        mockFee,
         system: { registry },
       } = await provider.snapshot(snapshot);
       const fee = randomAddress();
 
-      tx = registry.registerFee(fee);
+      tx = registry.registerFee(mockFee);
       await expect(tx).resolves.toBeReceipt();
 
-      tx = registry.registerFee(fee);
+      tx = registry.registerFee(mockFee);
       await expect(tx).rejects.toBeRevertedWith('_fee already registered');
     });
 
     it('fee is added', async () => {
       const {
+        mockFee,
         system: { registry },
       } = await provider.snapshot(snapshot);
-      const fee = randomAddress();
 
-      tx = registry.registerFee(fee);
+      tx = registry.registerFee(mockFee);
       await expect(tx).resolves.toBeReceipt();
       await expect(tx).resolves.toHaveEmitted('FeeAdded');
 
-      tx = registry.feeIsRegistered(fee);
+      tx = registry.feeIsRegistered(mockFee);
       await expect(tx).resolves.toBeTruthy();
     });
 

--- a/tests/tests/Registry.test.ts
+++ b/tests/tests/Registry.test.ts
@@ -8,13 +8,11 @@ let tx;
 async function snapshot(provider: BuidlerProvider) {
   const deployment = await configureTestDeployment()(provider);
   const {
-    config: {
-      deployer,
-    },
+    config: { deployer },
   } = deployment;
 
   const mockFee = await IFee.mock(deployer);
-  await mockFee.identifier.returns("MOCK");
+  await mockFee.identifier.returns('MOCK');
   await mockFee.feeHook.returns(1);
 
   return { ...deployment, mockFee };

--- a/tests/utils/fund/fees.ts
+++ b/tests/utils/fund/fees.ts
@@ -1,31 +1,40 @@
-import { BigNumberish, utils } from 'ethers';
+import { utils, BigNumberish } from 'ethers';
 
 export interface FeeParams {
   address: string;
-  rate: BigNumberish;
-  period: BigNumberish;
+  encoding: (string | utils.ParamType)[];
+  settings: any[];
 }
 
-export function managementFee(
-  rate: number = 0.1,
-  period: number = 30,
-  address: string,
-): FeeParams {
+export async function dummyFee(
+  address: string
+): Promise<FeeParams> {
   return {
     address: utils.getAddress(address),
-    rate: utils.parseEther(`${rate}`),
-    period: 60 * 60 * 24 * period,
+    encoding: [],
+    settings: [],
   };
 }
 
-export function performanceFee(
-  rate: number = 0.1,
-  period: number = 30,
+export async function managementFee(
   address: string,
-): FeeParams {
+  rate: BigNumberish
+): Promise<FeeParams> {
   return {
     address: utils.getAddress(address),
-    rate: utils.parseEther(`${rate}`),
-    period: 60 * 60 * 24 * period,
+    encoding: ['uint256'],
+    settings: [rate],
+  };
+}
+
+export async function performanceFee(
+  address: string,
+  rate: BigNumberish,
+  period: BigNumberish,
+): Promise<FeeParams> {
+  return {
+    address: utils.getAddress(address),
+    encoding: ['uint256', 'uint256'],
+    settings: [rate, period],
   };
 }

--- a/tests/utils/fund/fees.ts
+++ b/tests/utils/fund/fees.ts
@@ -6,9 +6,7 @@ export interface FeeParams {
   settings: any[];
 }
 
-export async function dummyFee(
-  address: string
-): Promise<FeeParams> {
+export async function dummyFee(address: string): Promise<FeeParams> {
   return {
     address: utils.getAddress(address),
     encoding: [],
@@ -18,7 +16,7 @@ export async function dummyFee(
 
 export async function managementFee(
   address: string,
-  rate: BigNumberish
+  rate: BigNumberish,
 ): Promise<FeeParams> {
   return {
     address: utils.getAddress(address),

--- a/tests/utils/fund/investing.ts
+++ b/tests/utils/fund/investing.ts
@@ -4,12 +4,12 @@ import { FundComponents } from './setup';
 import * as contracts from '../../contracts';
 
 // prettier-ignore
-export interface DemoninationAssetInterface extends Contract {
-  approve: Send<(spender: AddressLike, amount: BigNumberish) => boolean, DemoninationAssetInterface>;
+export interface DenominationAssetInterface extends Contract {
+  approve: Send<(spender: AddressLike, amount: BigNumberish) => boolean, DenominationAssetInterface>;
 }
 
 export interface RequestSharesParams {
-  denominationAsset: DemoninationAssetInterface;
+  denominationAsset: DenominationAssetInterface;
   fundComponents: FundComponents;
   sharesRequestor: contracts.SharesRequestor;
   amguValue?: BigNumberish;

--- a/tests/utils/fund/setup.ts
+++ b/tests/utils/fund/setup.ts
@@ -4,7 +4,7 @@ import { FeeParams } from './fees';
 import { PolicyParams } from './policies';
 import { stringToBytes, encodeArgs } from '../common';
 import {
-  DemoninationAssetInterface,
+  DenominationAssetInterface,
   requestShares,
   RequestSharesParams,
 } from './investing';
@@ -17,7 +17,7 @@ export type InitialInvestmentParams = Omit<
 
 export interface SetupFundParams {
   factory: contracts.FundFactory;
-  denominationAsset: DemoninationAssetInterface;
+  denominationAsset: DenominationAssetInterface;
   manager?: Signer;
   name?: string;
   adapters?: AddressLike[];
@@ -107,9 +107,9 @@ export interface FundComponents {
 
 export async function getFundComponents(
   address: string,
-  providider: Signer | providers.Provider,
+  provider: Signer | providers.Provider,
 ): Promise<FundComponents> {
-  const hub = new contracts.Hub(address, providider);
+  const hub = new contracts.Hub(address, provider);
   const [
     vaultAddress,
     sharesAddress,
@@ -122,12 +122,12 @@ export async function getFundComponents(
     hub.policyManager(),
   ]);
 
-  const vault = new contracts.Vault(vaultAddress, providider);
-  const shares = new contracts.Shares(sharesAddress, providider);
-  const feeManager = new contracts.FeeManager(feeManagerAddress, providider);
+  const vault = new contracts.Vault(vaultAddress, provider);
+  const shares = new contracts.Shares(sharesAddress, provider);
+  const feeManager = new contracts.FeeManager(feeManagerAddress, provider);
   const policyManager = new contracts.PolicyManager(
     policyManagerAddress,
-    providider,
+    provider,
   );
 
   return {

--- a/tests/utils/fund/setup.ts
+++ b/tests/utils/fund/setup.ts
@@ -48,9 +48,7 @@ export async function setupFundWithParams({
     resolveAddress(denominationAsset),
     Promise.all(adapters.map((address) => resolveAddress(address))),
     Promise.all(fees.map((item) => resolveAddress(item.address))),
-    Promise.all(
-      fees.map((item) => encodeArgs(item.encoding, item.settings)),
-    ),
+    Promise.all(fees.map((item) => encodeArgs(item.encoding, item.settings))),
     Promise.all(policies.map((item) => resolveAddress(item.address))),
     Promise.all(
       policies.map((item) => encodeArgs(item.encoding, item.settings)),

--- a/tests/utils/fund/setup.ts
+++ b/tests/utils/fund/setup.ts
@@ -36,20 +36,22 @@ export async function setupFundWithParams({
   investment,
 }: SetupFundParams) {
   const fundName = stringToBytes(name);
-  const feesRates = fees.map((item) => item.rate);
-  const feesPeriods = fees.map((item) => item.period);
 
   const [
     denominationAssetAddress,
     adapterAddresses,
-    policiesAddresses,
     feesAddresses,
+    feesSettings,
+    policiesAddresses,
     policiesSettings,
   ] = await Promise.all([
     resolveAddress(denominationAsset),
     Promise.all(adapters.map((address) => resolveAddress(address))),
-    Promise.all(policies.map((item) => resolveAddress(item.address))),
     Promise.all(fees.map((item) => resolveAddress(item.address))),
+    Promise.all(
+      fees.map((item) => encodeArgs(item.encoding, item.settings)),
+    ),
+    Promise.all(policies.map((item) => resolveAddress(item.address))),
     Promise.all(
       policies.map((item) => encodeArgs(item.encoding, item.settings)),
     ),
@@ -58,8 +60,7 @@ export async function setupFundWithParams({
   await factory.beginFundSetup(
     fundName,
     feesAddresses,
-    feesRates,
-    feesPeriods,
+    feesSettings,
     policiesAddresses,
     policiesSettings,
     adapterAddresses,


### PR DESCRIPTION
This PR is basically a complete re-write of `FeeManager` and the way that fees work, including re-writes of `ManagementFee` and `PerformanceFee` as well. The goal is abstraction, where the FeeManager is not hardcoded with idiosyncrasies to suit any fee (or combination of particular fees), but rather it can facilitate a wide range of potential fee implementations.

Rather than imposing knowledge of particular fees on the `FeeManager` (e.g., fee #1 is a management fee and fee #2 is a performance fee, and must be called in this order), the `FeeManager` is un-opinionated about the identities of particular fees. Instead, it only cares about the fee's type (its `FeeHook`), which is specified by the caller of fee settlement (e.g., `Shares` will call `FeeManager.settleFees()` with `FeeHook.BuyShares` when buying shares and with `FeeHook.Continuous` before any change to `Shares.totalSupply` (i.e., any attempt to buy or sell shares).

The main point of complexity is the way that fees are distributed, allowing for shares due to be optionally held for payout at a later time. For policies such as `PerformanceFee`, we want to continuously add/subtract from a running count of "shares outstanding", so that frequent entries/exits of investors do not create an unfair handicap for late investors (i.e., paying for performance they did not receive). The `FeeManager` thus gives fees the chance to respond to two calls: "settlement" and "payout of shares outstanding". Some fees such as `ManagementFee` only implement settlement and distribute shares to the fund manager (or any recipient) immediately, which others such as `PerformanceFee` take shares into the fee's custody until they are able to be unlocked by some condition. The `FeeManager` serves as the coordinator of these distributions, differentially minting and burning shares to/from the various parties as dictated by the fees (again, the FeeManager stays un-opinionated about the parties and amount involved).

The individual fees themselves have been re-structured into base contracts that provide helper functions and setup common to a particular type of fee (only `ContinuousFeeBase` for this PR, but will also need one for `BuySharesFeeBase`).

It should be noted that `PerformanceFee` is likely to change heavily, and should be considered a work-in-progress at this stage.

Also, there are no policy implementations for `FeeHook.BuyShares`, which we will definitely want before the release.