### PR TITLE
refactor: move adapter config from Registry to adapters

### DIFF
--- a/src/fund/policies/TradingSignatures.sol
+++ b/src/fund/policies/TradingSignatures.sol
@@ -5,5 +5,5 @@ pragma solidity 0.6.8;
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Hard-coded signatures
 contract TradingSignatures {
-    bytes4 constant public TAKE_ORDER = 0x344ef5f2;
+    bytes4 constant public TAKE_ORDER = bytes4(keccak256("takeOrder(bytes)"));
 }

--- a/src/integrations/adapters/AirSwapAdapter.sol
+++ b/src/integrations/adapters/AirSwapAdapter.sol
@@ -9,6 +9,18 @@ import "../libs/OrderTaker.sol";
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Adapter between Melon and AirSwap
 contract AirSwapAdapter is OrderTaker {
+    address immutable public EXCHANGE;
+
+    constructor(address _exchange) public {
+        EXCHANGE = _exchange;
+    }
+
+    /// @notice Provides a constant string identifier for an adapter
+    /// @return An identifier string
+    function identifier() external pure override returns (string memory) {
+        return "AIRSWAP";
+    }
+
     /// @notice Extract arguments for risk management validations of a takeOrder call
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return riskManagementAddresses_ needed addresses for risk management
@@ -22,10 +34,7 @@ contract AirSwapAdapter is OrderTaker {
     /// - [0] Maker asset amount
     /// - [1] Taker asset amount
     /// - [2] Taker asset fill amount
-    function __extractTakeOrderRiskManagementArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __extractTakeOrderRiskManagementArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -52,17 +61,12 @@ contract AirSwapAdapter is OrderTaker {
     }
 
     /// @notice Take a market order on AirSwap (takeOrder)
-    /// @param _targetExchange Address of AirSwap exchange contract
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @param _fillData Encoded data to pass to OrderFiller
-    function __fillTakeOrder(
-        address _targetExchange,
-        bytes memory _encodedArgs,
-        bytes memory _fillData
-    )
+    function __fillTakeOrder(bytes memory _encodedArgs, bytes memory _fillData)
         internal
         override
-        validateAndFinalizeFilledOrder(_targetExchange, _fillData)
+        validateAndFinalizeFilledOrder(_fillData)
     {
         (
             address[6] memory orderAddresses,
@@ -82,11 +86,10 @@ contract AirSwapAdapter is OrderTaker {
             version
         );
 
-        ISwap(_targetExchange).swap(order);
+        ISwap(EXCHANGE).swap(order);
     }
 
     /// @notice Formats arrays of _fillAssets and their _fillExpectedAmounts for a takeOrder call
-    /// @param _targetExchange Address of AirSwap exchange contract
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return fillAssets_ Assets to fill
     /// - [0] Maker asset
@@ -97,10 +100,7 @@ contract AirSwapAdapter is OrderTaker {
     /// @return fillApprovalTargets_ Recipients of assets in fill order
     /// - [0] Taker (fund), set to address(0)
     /// - [1] AirSwap exchange of taker asset
-    function __formatFillTakeOrderArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __formatFillTakeOrderArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -121,18 +121,14 @@ contract AirSwapAdapter is OrderTaker {
 
         address[] memory fillApprovalTargets = new address[](2);
         fillApprovalTargets[0] = address(0); // Fund (Use 0x0)
-        fillApprovalTargets[1] = _targetExchange;
+        fillApprovalTargets[1] = EXCHANGE;
 
         return (fillAssets, fillExpectedAmounts, fillApprovalTargets);
     }
 
     /// @notice Validate the parameters of a takeOrder call
-    /// @param _targetExchange Address of AirSwap exchange contract
     /// @param _encodedArgs Encoded parameters passed from client side
-    function __validateTakeOrderParams(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __validateTakeOrderParams(bytes memory _encodedArgs)
         internal
         view
         override

--- a/src/integrations/adapters/KyberAdapter.sol
+++ b/src/integrations/adapters/KyberAdapter.sol
@@ -11,6 +11,18 @@ import "../../dependencies/WETH.sol";
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Adapter between Melon and Kyber Network
 contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
+    address immutable public EXCHANGE;
+
+    constructor(address _exchange) public {
+        EXCHANGE = _exchange;
+    }
+
+    /// @notice Provides a constant string identifier for an adapter
+    /// @return An identifier string
+    function identifier() external pure override returns (string memory) {
+        return "KYBER_NETWORK";
+    }
+
     /// @notice Extract arguments for risk management validations of a takeOrder call
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return riskManagementAddresses_ needed addresses for risk management
@@ -24,10 +36,7 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
     /// - [0] Maker asset amount
     /// - [1] Taker asset amount
     /// - [2] Taker asset fill amount
-    function __extractTakeOrderRiskManagementArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __extractTakeOrderRiskManagementArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -56,17 +65,12 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
     }
 
     /// @notice Take a market order on Kyber Swap (takeOrder)
-    /// @param _targetExchange Address of the Kyber exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @param _fillData Encoded data to pass to OrderFiller
-    function __fillTakeOrder(
-        address _targetExchange,
-        bytes memory _encodedArgs,
-        bytes memory _fillData
-    )
+    function __fillTakeOrder(bytes memory _encodedArgs, bytes memory _fillData)
         internal
         override
-        validateAndFinalizeFilledOrder(_targetExchange, _fillData)
+        validateAndFinalizeFilledOrder(_fillData)
     {
         (
             address[] memory fillAssets,
@@ -75,30 +79,17 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
 
         // Execute order on exchange, depending on asset types
         if (fillAssets[1] == __getNativeAssetAddress()) {
-            __swapNativeAssetToToken(
-                _targetExchange,
-                fillAssets,
-                fillExpectedAmounts
-            );
+            __swapNativeAssetToToken(fillAssets, fillExpectedAmounts);
         }
         else if (fillAssets[0] == __getNativeAssetAddress()) {
-            __swapTokenToNativeAsset(
-                _targetExchange,
-                fillAssets,
-                fillExpectedAmounts
-            );
+            __swapTokenToNativeAsset(fillAssets, fillExpectedAmounts);
         }
         else {
-            __swapTokenToToken(
-                _targetExchange,
-                fillAssets,
-                fillExpectedAmounts
-            );
+            __swapTokenToToken(fillAssets, fillExpectedAmounts);
         }
     }
 
     /// @notice Formats arrays of _fillAssets and their _fillExpectedAmounts for a takeOrder call
-    /// @param _targetExchange Address of the Kyber exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return fillAssets_ Assets to fill
     /// - [0] Maker asset (same as _orderAddresses[2])
@@ -108,11 +99,8 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
     /// - [1] Expected (max) quantity of taker asset to spend
     /// @return fillApprovalTargets_ Recipients of assets in fill order
     /// - [0] Taker (fund), set to address(0)
-    /// - [1] Kyber exchange (_targetExchange)
-    function __formatFillTakeOrderArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    /// - [1] Kyber exchange (EXCHANGE)
+    function __formatFillTakeOrderArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -137,18 +125,14 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
         fillApprovalTargets[0] = address(0); // Fund (Use 0x0)
         fillApprovalTargets[1] = fillAssets[1] == __getNativeAssetAddress() ?
             address(0) :
-            _targetExchange; // Kyber exchange
+            EXCHANGE; // Kyber exchange
 
         return (fillAssets, fillExpectedAmounts, fillApprovalTargets);
     }
 
     /// @notice Validate the parameters of a takeOrder call
-    /// @param _targetExchange Address of the Kyber exchange
     /// @param _encodedArgs Encoded parameters passed from client side
-    function __validateTakeOrderParams(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __validateTakeOrderParams(bytes memory _encodedArgs)
         internal
         view
         override
@@ -189,7 +173,6 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
 
     /// @notice Executes a swap of ETH (taker) to ERC20 (maker)
     function __swapNativeAssetToToken(
-        address _targetExchange,
         address[] memory _fillAssets,
         uint256[] memory _fillExpectedAmounts
     )
@@ -204,7 +187,7 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
         WETH(payable(_fillAssets[1])).withdraw(_fillExpectedAmounts[1]);
 
         // Swap tokens
-        IKyberNetworkProxy(_targetExchange).swapEtherToToken.value(
+        IKyberNetworkProxy(EXCHANGE).swapEtherToToken.value(
             _fillExpectedAmounts[1]
         )
         (
@@ -215,14 +198,13 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
 
     /// @notice Executes a swap of ERC20 (taker) to ETH (maker)
     function __swapTokenToNativeAsset(
-        address _targetExchange,
         address[] memory _fillAssets,
         uint256[] memory _fillExpectedAmounts
     )
         private
     {
         uint256 preEthBalance = payable(address(this)).balance;
-        IKyberNetworkProxy(_targetExchange).swapTokenToEther(
+        IKyberNetworkProxy(EXCHANGE).swapTokenToEther(
             _fillAssets[1],
             _fillExpectedAmounts[1],
             __calcMinMakerAssetPerTakerAssetRate(_fillAssets, _fillExpectedAmounts)
@@ -235,13 +217,12 @@ contract KyberAdapter is OrderTaker, MinimalTakeOrderDecoder {
 
     /// @notice Executes a swap of ERC20 (taker) to ERC20 (maker)
     function __swapTokenToToken(
-        address _targetExchange,
         address[] memory _fillAssets,
         uint256[] memory _fillExpectedAmounts
     )
         private
     {
-        IKyberNetworkProxy(_targetExchange).swapTokenToToken(
+        IKyberNetworkProxy(EXCHANGE).swapTokenToToken(
             _fillAssets[1],
             _fillExpectedAmounts[1],
             _fillAssets[0],

--- a/src/integrations/adapters/ZeroExV2Adapter.sol
+++ b/src/integrations/adapters/ZeroExV2Adapter.sol
@@ -9,6 +9,18 @@ import "../libs/OrderTaker.sol";
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Adapter to 0xV2 Exchange Contract
 contract ZeroExV2Adapter is OrderTaker {
+    address immutable public EXCHANGE;
+
+    constructor(address _exchange) public {
+        EXCHANGE = _exchange;
+    }
+
+    /// @notice Provides a constant string identifier for an adapter
+    /// @return An identifier string
+    function identifier() external pure override returns (string memory) {
+        return "ZERO_EX_V2";
+    }
+
     /// @notice Extract arguments for risk management validations of a takeOrder call
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return riskManagementAddresses_ needed addresses for risk management
@@ -22,10 +34,7 @@ contract ZeroExV2Adapter is OrderTaker {
     /// - [0] Maker asset amount
     /// - [1] Taker asset amount
     /// - [2] Taker asset fill amount
-    function __extractTakeOrderRiskManagementArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __extractTakeOrderRiskManagementArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -37,7 +46,7 @@ contract ZeroExV2Adapter is OrderTaker {
             bytes[2] memory orderData,
         ) = __decodeTakeOrderArgs(_encodedArgs);
 
-        address zrxAsset = __getAssetAddress(IZeroExV2(_targetExchange).ZRX_ASSET_DATA());
+        address zrxAsset = __getAssetAddress(IZeroExV2(EXCHANGE).ZRX_ASSET_DATA());
 
         riskManagementAddresses_ = [
             orderAddresses[0],
@@ -55,17 +64,12 @@ contract ZeroExV2Adapter is OrderTaker {
     }
 
     /// @notice Takes an active order on 0x v2 (takeOrder)
-    /// @param _targetExchange Address of 0x v2 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @param _fillData Encoded data to pass to OrderFiller
-    function __fillTakeOrder(
-        address _targetExchange,
-        bytes memory _encodedArgs,
-        bytes memory _fillData
-    )
+    function __fillTakeOrder(bytes memory _encodedArgs, bytes memory _fillData)
         internal
         override
-        validateAndFinalizeFilledOrder(_targetExchange, _fillData)
+        validateAndFinalizeFilledOrder(_fillData)
     {
         (
             address[4] memory orderAddresses,
@@ -77,7 +81,7 @@ contract ZeroExV2Adapter is OrderTaker {
         (,uint256[] memory fillExpectedAmounts,) = __decodeOrderFillData(_fillData);
 
         // Execute take order on exchange
-        IZeroExV2(_targetExchange).fillOrder(
+        IZeroExV2(EXCHANGE).fillOrder(
             __constructOrderStruct(orderAddresses, orderValues, orderData),
             fillExpectedAmounts[1],
             signature
@@ -85,7 +89,6 @@ contract ZeroExV2Adapter is OrderTaker {
     }
 
     /// @notice Formats arrays of _fillAssets and their _fillExpectedAmounts for a takeOrder call
-    /// @param _targetExchange Address of 0x v2 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return fillAssets_ Assets to fill
     /// - [0] Maker asset (same as _orderAddresses[2])
@@ -99,10 +102,7 @@ contract ZeroExV2Adapter is OrderTaker {
     /// - [0] Taker (fund), set to address(0)
     /// - [1] 0x asset proxy for the taker asset
     /// - [2] 0x asset proxy for the taker fee asset (ZRX)
-    function __formatFillTakeOrderArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __formatFillTakeOrderArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -117,7 +117,7 @@ contract ZeroExV2Adapter is OrderTaker {
         address[] memory fillAssets = new address[](3);
         fillAssets[0] = __getAssetAddress(orderData[0]); // maker asset
         fillAssets[1] = __getAssetAddress(orderData[1]); // taker asset
-        fillAssets[2] = __getAssetAddress(IZeroExV2(_targetExchange).ZRX_ASSET_DATA()); // taker fee asset
+        fillAssets[2] = __getAssetAddress(IZeroExV2(EXCHANGE).ZRX_ASSET_DATA()); // taker fee asset
 
         uint256[] memory fillExpectedAmounts = new uint256[](3);
         fillExpectedAmounts[0] = __calculateRelativeQuantity(
@@ -134,22 +134,17 @@ contract ZeroExV2Adapter is OrderTaker {
 
         address[] memory fillApprovalTargets = new address[](3);
         fillApprovalTargets[0] = address(0); // Fund (Use 0x0)
-        fillApprovalTargets[1] = __getAssetProxy(_targetExchange, orderData[1]); // 0x asset proxy for taker asset
-        fillApprovalTargets[2] = __getAssetProxy(
-            _targetExchange,
-            IZeroExV2(_targetExchange).ZRX_ASSET_DATA()
-        ); // 0x asset proxy for taker fee asset (ZRX)
+        // 0x asset proxy for taker asset
+        fillApprovalTargets[1] = __getAssetProxy(orderData[1]);
+        // 0x asset proxy for taker fee asset (ZRX)
+        fillApprovalTargets[2] = __getAssetProxy(IZeroExV2(EXCHANGE).ZRX_ASSET_DATA());
 
         return (fillAssets, fillExpectedAmounts, fillApprovalTargets);
     }
 
     /// @notice Validate the parameters of a takeOrder call
-    /// @param _targetExchange Address of 0x v2 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
-    function __validateTakeOrderParams(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __validateTakeOrderParams(bytes memory _encodedArgs)
         internal
         view
         override
@@ -204,7 +199,7 @@ contract ZeroExV2Adapter is OrderTaker {
     }
 
     /// @notice Gets the 0x assetProxy address for an ERC20 token
-    function __getAssetProxy(address _targetExchange, bytes memory _assetData)
+    function __getAssetProxy(bytes memory _assetData)
         private
         view
         returns (address assetProxy_)
@@ -216,7 +211,7 @@ contract ZeroExV2Adapter is OrderTaker {
                 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000
             )
         }
-        assetProxy_ = IZeroExV2(_targetExchange).getAssetProxy(assetProxyId);
+        assetProxy_ = IZeroExV2(EXCHANGE).getAssetProxy(assetProxyId);
     }
 
     /// @notice Parses the asset address from 0x assetData

--- a/src/integrations/adapters/ZeroExV3Adapter.sol
+++ b/src/integrations/adapters/ZeroExV3Adapter.sol
@@ -9,6 +9,18 @@ import "../libs/OrderTaker.sol";
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Adapter to 0xV3 Exchange Contract
 contract ZeroExV3Adapter is OrderTaker {
+    address immutable public EXCHANGE;
+
+    constructor(address _exchange) public {
+        EXCHANGE = _exchange;
+    }
+
+    /// @notice Provides a constant string identifier for an adapter
+    /// @return An identifier string
+    function identifier() external pure override returns (string memory) {
+        return "ZERO_EX_V3";
+    }
+
     /// @notice Extract arguments for risk management validations
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return riskManagementAddresses_ needed addresses for risk management
@@ -22,10 +34,7 @@ contract ZeroExV3Adapter is OrderTaker {
     /// - [0] Maker asset amount
     /// - [1] Taker asset amount
     /// - [2] Taker asset fill amount
-    function __extractTakeOrderRiskManagementArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __extractTakeOrderRiskManagementArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -53,17 +62,12 @@ contract ZeroExV3Adapter is OrderTaker {
     }
 
     /// @notice Takes an active order on 0x v3 (takeOrder)
-    /// @param _targetExchange Address of 0x v3 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @param _fillData Encoded data to pass to OrderFiller
-    function __fillTakeOrder(
-        address _targetExchange,
-        bytes memory _encodedArgs,
-        bytes memory _fillData
-    )
+    function __fillTakeOrder(bytes memory _encodedArgs, bytes memory _fillData)
         internal
         override
-        validateAndFinalizeFilledOrder(_targetExchange, _fillData)
+        validateAndFinalizeFilledOrder(_fillData)
     {
         (
             address[4] memory orderAddresses,
@@ -75,7 +79,7 @@ contract ZeroExV3Adapter is OrderTaker {
         (,uint256[] memory fillExpectedAmounts,) = __decodeOrderFillData(_fillData);
 
         // Execute take order on exchange
-        IZeroExV3(_targetExchange).fillOrder(
+        IZeroExV3(EXCHANGE).fillOrder(
             __constructOrderStruct(orderAddresses, orderValues, orderData),
             fillExpectedAmounts[1],
             signature
@@ -83,7 +87,6 @@ contract ZeroExV3Adapter is OrderTaker {
     }
 
     /// @notice Formats arrays of _fillAssets and their _fillExpectedAmounts for a takeOrder call
-    /// @param _targetExchange Address of 0x v3 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @return fillAssets_ Assets to fill
     /// - [0] Maker asset (same as _orderAddresses[2])
@@ -100,10 +103,7 @@ contract ZeroExV3Adapter is OrderTaker {
     /// - [1] 0x asset proxy for the taker asset
     /// - [2] 0x protocolFeeCollector
     /// - [3] 0x asset proxy for the taker fee asset
-    function __formatFillTakeOrderArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __formatFillTakeOrderArgs(bytes memory _encodedArgs)
         internal
         view
         override
@@ -127,7 +127,7 @@ contract ZeroExV3Adapter is OrderTaker {
             orderValues[6]
         ); // maker fill amount; calculated relative to taker fill amount
         fillExpectedAmounts[1] = orderValues[6]; // taker fill amount
-        fillExpectedAmounts[2] = __calcProtocolFeeAmount(_targetExchange); // protocol fee
+        fillExpectedAmounts[2] = __calcProtocolFeeAmount(); // protocol fee
         fillExpectedAmounts[3] = __calculateRelativeQuantity(
             orderValues[1],
             orderValues[3],
@@ -136,20 +136,16 @@ contract ZeroExV3Adapter is OrderTaker {
 
         address[] memory fillApprovalTargets = new address[](4);
         fillApprovalTargets[0] = address(0); // Fund (Use 0x0)
-        fillApprovalTargets[1] = __getAssetProxy(_targetExchange, orderData[1]); // 0x asset proxy for taker asset
-        fillApprovalTargets[2] = IZeroExV3(_targetExchange).protocolFeeCollector(); // 0x protocol fee collector
-        fillApprovalTargets[3] = __getAssetProxy(_targetExchange, orderData[3]); // 0x asset proxy for taker fee asset
+        fillApprovalTargets[1] = __getAssetProxy(orderData[1]); // 0x asset proxy for taker asset
+        fillApprovalTargets[2] = IZeroExV3(EXCHANGE).protocolFeeCollector(); // 0x protocol fee collector
+        fillApprovalTargets[3] = __getAssetProxy(orderData[3]); // 0x asset proxy for taker fee asset
 
         return (fillAssets, fillExpectedAmounts, fillApprovalTargets);
     }
 
     /// @notice Validate the parameters of a takeOrder call
-    /// @param _targetExchange Address of 0x v3 exchange
     /// @param _encodedArgs Encoded parameters passed from client side
-    function __validateTakeOrderParams(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __validateTakeOrderParams(bytes memory _encodedArgs)
         internal
         view
         override
@@ -181,7 +177,7 @@ contract ZeroExV3Adapter is OrderTaker {
             "__validateTakeOrderParams: taker fill amount greater than max order quantity"
         );
         require(
-            IZeroExV3(_targetExchange).isValidOrderSignature(
+            IZeroExV3(EXCHANGE).isValidOrderSignature(
                 __constructOrderStruct(orderAddresses, orderValues, orderData),
                 signature
             ),
@@ -191,8 +187,8 @@ contract ZeroExV3Adapter is OrderTaker {
 
     // PRIVATE FUNCTIONS
 
-    function __calcProtocolFeeAmount(address _targetExchange) private view returns (uint256) {
-        return mul(IZeroExV3(_targetExchange).protocolFeeMultiplier(), tx.gasprice);
+    function __calcProtocolFeeAmount() private view returns (uint256) {
+        return mul(IZeroExV3(EXCHANGE).protocolFeeMultiplier(), tx.gasprice);
     }
 
     /// @notice Parses user inputs into a ZeroExV3.Order format
@@ -224,7 +220,7 @@ contract ZeroExV3Adapter is OrderTaker {
     }
 
     /// @notice Gets the 0x assetProxy address for an ERC20 token
-    function __getAssetProxy(address _targetExchange, bytes memory _assetData)
+    function __getAssetProxy(bytes memory _assetData)
         private
         view
         returns (address assetProxy_)
@@ -236,7 +232,7 @@ contract ZeroExV3Adapter is OrderTaker {
                 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000
             )
         }
-        assetProxy_ = IZeroExV3(_targetExchange).getAssetProxy(assetProxyId);
+        assetProxy_ = IZeroExV3(EXCHANGE).getAssetProxy(assetProxyId);
     }
 
     /// @notice Parses the asset address from 0x assetData

--- a/src/integrations/libs/IIntegrationAdapter.sol
+++ b/src/integrations/libs/IIntegrationAdapter.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.6.8;
+
+/// @title Integration Adapter interface
+/// @author Melon Council DAO <security@meloncoucil.io>
+interface IIntegrationAdapter {
+    function identifier() external pure returns (string memory);
+}

--- a/src/integrations/libs/IntegrationAdapter.sol
+++ b/src/integrations/libs/IntegrationAdapter.sol
@@ -7,11 +7,12 @@ import "../../dependencies/token/IERC20.sol";
 import "../../fund/hub/IHub.sol";
 import "../../fund/hub/ISpoke.sol";
 import "../../registry/IRegistry.sol";
+import "./IIntegrationAdapter.sol";
 
 /// @title Integration Adapter base contract
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Provides convenience functions for use in integration adapters
-abstract contract IntegrationAdapter is DSMath {
+abstract contract IntegrationAdapter is IIntegrationAdapter, DSMath {
     /// @notice Increment allowance of an asset for some target
     /// @dev Checks the actual in-contract assetBalances (as opposed to "holdings")
     function __approveAsset(

--- a/src/integrations/libs/OrderTaker.sol
+++ b/src/integrations/libs/OrderTaker.sol
@@ -14,19 +14,13 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
     /// @dev Synchronously handles the responsibilities of takeOrder:
     /// - Validate user inputs
     /// - Prepare a formatted list of assets and their expected fill amounts
-    /// - Fill an order on the _targetExchange (with validateAndFinalizeFilledOrder)
-    /// @param _targetExchange Order maker
+    /// - Fill an order (with validateAndFinalizeFilledOrder)
     /// @param _encodedArgs Encoded parameters passed from client side
-    function takeOrder (
-        address _targetExchange,
-        bytes calldata _encodedArgs
-    )
-        external
-    {
+    function takeOrder (bytes calldata _encodedArgs) external {
         (
             address[6] memory riskManagementAddresses,
             uint256[3] memory riskManagementValues
-        ) = __extractTakeOrderRiskManagementArgs(_targetExchange, _encodedArgs);
+        ) = __extractTakeOrderRiskManagementArgs(_encodedArgs);
 
         // TODO: OasisDex identifier is not 0x0
         address policyManagerAddress = IHub(ISpoke(address(this)).HUB()).policyManager();
@@ -37,28 +31,21 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
                 riskManagementAddresses[1],
                 riskManagementAddresses[2],
                 riskManagementAddresses[3],
-                _targetExchange
+                address(0) // temp placeholder, as this is no longer validated here in the new policy manager PR
             ],
             riskManagementValues,
             0x0
         );
 
-        __validateTakeOrderParams(
-            _targetExchange,
-            _encodedArgs
-        );
+        __validateTakeOrderParams(_encodedArgs);
 
         (
             address[] memory fillAssets,
             uint256[] memory fillExpectedAmounts,
             address[] memory fillApprovalTargets
-        ) = __formatFillTakeOrderArgs(
-            _targetExchange,
-            _encodedArgs
-        );
+        ) = __formatFillTakeOrderArgs(_encodedArgs);
 
         __fillTakeOrder(
-            _targetExchange,
             _encodedArgs,
             __encodeOrderFillData(fillAssets, fillExpectedAmounts, fillApprovalTargets)
         );
@@ -70,7 +57,7 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
                 riskManagementAddresses[1],
                 riskManagementAddresses[2],
                 riskManagementAddresses[3],
-                _targetExchange
+                address(0) // temp placeholder, as this is no longer validated here in the new policy manager PR
             ],
             riskManagementValues,
             0x0
@@ -92,10 +79,7 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
     /// - [0] Maker asset amount
     /// - [1] Taker asset amount
     /// - [2] Taker asset fill amount
-    function __extractTakeOrderRiskManagementArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __extractTakeOrderRiskManagementArgs(bytes memory _encodedArgs)
         internal
         view
         virtual
@@ -106,11 +90,7 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
     /// @dev Include the `validateAndFinalizeFilledOrder` modifier
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @param _fillData Encoded data used by the OrderFiller
-    function __fillTakeOrder(
-        address _targetExchange,
-        bytes memory _encodedArgs,
-        bytes memory _fillData
-    )
+    function __fillTakeOrder(bytes memory _encodedArgs, bytes memory _fillData)
         internal
         virtual;
 
@@ -120,10 +100,7 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
     /// @return fillAssets_ Addresses of filled assets
     /// @return fillExpectedAmounts_ Expected amounts of asset fills
     /// @return fillApprovalTargets_ Targets to approve() for asset fills
-    function __formatFillTakeOrderArgs(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __formatFillTakeOrderArgs(bytes memory _encodedArgs)
         internal
         view
         virtual
@@ -136,10 +113,7 @@ abstract contract OrderTaker is OrderFiller, TradingSignatures {
     /// @notice Reserved function for validating the parameters of a takeOrder call
     /// @param _encodedArgs Encoded parameters passed from client side
     /// @dev Use this to perform validation of takeOrder's inputs
-    function __validateTakeOrderParams(
-        address _targetExchange,
-        bytes memory _encodedArgs
-    )
+    function __validateTakeOrderParams(bytes memory _encodedArgs)
         internal
         view
         virtual;

--- a/tests/unit/exchanges/adapters/kyberAdapter.test.js
+++ b/tests/unit/exchanges/adapters/kyberAdapter.test.js
@@ -161,7 +161,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.KYBER_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(kyberNetworkProxy.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);
@@ -268,7 +267,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.KYBER_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(kyberNetworkProxy.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);
@@ -375,7 +373,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.KYBER_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(kyberNetworkProxy.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);

--- a/tests/unit/exchanges/adapters/local/engineAdapterLocal.test.js
+++ b/tests/unit/exchanges/adapters/local/engineAdapterLocal.test.js
@@ -162,7 +162,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ENGINE_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(engine.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);
@@ -271,7 +270,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ENGINE_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(engine.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);

--- a/tests/unit/exchanges/adapters/oasisDexAdapter.test.js
+++ b/tests/unit/exchanges/adapters/oasisDexAdapter.test.js
@@ -280,7 +280,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.OASIS_DEX_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(oasisDexExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);

--- a/tests/unit/exchanges/adapters/uniswapAdapter.test.js
+++ b/tests/unit/exchanges/adapters/uniswapAdapter.test.js
@@ -203,7 +203,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.UNISWAP_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(uniswapFactory.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);
@@ -305,7 +304,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.UNISWAP_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(uniswapFactory.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);
@@ -412,7 +410,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.UNISWAP_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(uniswapFactory.options.address);
       expect(orderFilled.buyAsset).toBe(makerAsset);
       expect(orderFilled.buyAmount).toBe(makerQuantity);
       expect(orderFilled.sellAsset).toBe(takerAsset);

--- a/tests/unit/exchanges/adapters/zeroExV2Adapter.test.js
+++ b/tests/unit/exchanges/adapters/zeroExV2Adapter.test.js
@@ -238,7 +238,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V2_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -387,7 +386,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V2_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -536,7 +534,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V2_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(new BN(orderFilled.buyAmount)).bigNumberEq(makerFillQuantity);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);

--- a/tests/unit/exchanges/adapters/zeroExV3Adapter.test.js
+++ b/tests/unit/exchanges/adapters/zeroExV3Adapter.test.js
@@ -263,7 +263,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -401,7 +400,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -558,7 +556,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -735,7 +732,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -877,7 +873,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(orderFilled.buyAmount).toBe(signedOrder.makerAssetAmount);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);
@@ -1015,7 +1010,6 @@ describe('takeOrder', () => {
         CONTRACT_NAMES.ZERO_EX_V3_ADAPTER,
         'OrderFilled'
       );
-      expect(orderFilled.targetContract).toBe(zeroExExchange.options.address);
       expect(orderFilled.buyAsset).toBe(makerTokenAddress);
       expect(new BN(orderFilled.buyAmount)).bigNumberEq(makerFillQuantity);
       expect(orderFilled.sellAsset).toBe(takerTokenAddress);


### PR DESCRIPTION
This PR moves the relevant info for identifying and using adapters to the adapter contracts. Previously, this was not possible because of the way we call adapters (via a delegatecall), but it is not possible to dynamically define `immutable` constants at deploy time (i.e., the integration gateway address for the adapter).

Notes:
- moved adapter "gateway" from Registry into an `immutable` type on the adapters themselves
- added a required `identifier()` function to adapters via an `IIntegrationAdapter` interface, and require that only 1 adapter per identifier exist in the Registry. This is prevent having multiple versions of the same adapter registered. (we do the same for policies and fees in those respective PRs)
- removed the concept of `integrationType` entirely. Some adapters can have multiple types, e.g., a `CompoundAdapter` could be both lending and borrowing. In terms of policies, it makes more sense to (dis)allow function sigs (e.g., allow lend but disallow borrow)