### PR TITLE
chore: add gpl license comment to the top of solidity files

### DIFF
--- a/src/dependencies/TokenUser.sol
+++ b/src/dependencies/TokenUser.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "./token/IERC20.sol";

--- a/src/dependencies/token/BurnableToken.sol
+++ b/src/dependencies/token/BurnableToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "./PreminedToken.sol";

--- a/src/dependencies/token/IERC20Flexible.sol
+++ b/src/dependencies/token/IERC20Flexible.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Flexible ERC20 interface

--- a/src/dependencies/token/PreminedToken.sol
+++ b/src/dependencies/token/PreminedToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "./StandardToken.sol";

--- a/src/engine/AmguConsumer.sol
+++ b/src/engine/AmguConsumer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../dependencies/DSMath.sol";

--- a/src/engine/Engine.sol
+++ b/src/engine/Engine.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../dependencies/DSMath.sol";

--- a/src/engine/IEngine.sol
+++ b/src/engine/IEngine.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Engine Interface

--- a/src/factory/FundFactory.sol
+++ b/src/factory/FundFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/fund/fees/FeeManager.sol
+++ b/src/fund/fees/FeeManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/fund/fees/IFee.sol
+++ b/src/fund/fees/IFee.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Fee Interface

--- a/src/fund/fees/IFeeManager.sol
+++ b/src/fund/fees/IFeeManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title FeeManager Interface

--- a/src/fund/fees/ManagementFee.sol
+++ b/src/fund/fees/ManagementFee.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../dependencies/DSMath.sol";

--- a/src/fund/fees/PerformanceFee.sol
+++ b/src/fund/fees/PerformanceFee.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../dependencies/DSMath.sol";

--- a/src/fund/hub/FundRouterMixin.sol
+++ b/src/fund/hub/FundRouterMixin.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../registry/IRegistry.sol";

--- a/src/fund/hub/Hub.sol
+++ b/src/fund/hub/Hub.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../registry/IRegistry.sol";

--- a/src/fund/hub/IHub.sol
+++ b/src/fund/hub/IHub.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Hub Interface

--- a/src/fund/hub/ISpoke.sol
+++ b/src/fund/hub/ISpoke.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/fund/hub/Spoke.sol
+++ b/src/fund/hub/Spoke.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../registry/IRegistry.sol";

--- a/src/fund/policies/AddressList.sol
+++ b/src/fund/policies/AddressList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../dependencies/DSAuth.sol";

--- a/src/fund/policies/IPolicy.sol
+++ b/src/fund/policies/IPolicy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Policy Interface

--- a/src/fund/policies/IPolicyManager.sol
+++ b/src/fund/policies/IPolicyManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title PolicyManager Interface

--- a/src/fund/policies/PolicyManager.sol
+++ b/src/fund/policies/PolicyManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/fund/policies/TradingSignatures.sol
+++ b/src/fund/policies/TradingSignatures.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title TradingSignatures Contract

--- a/src/fund/policies/compliance/UserWhitelist.sol
+++ b/src/fund/policies/compliance/UserWhitelist.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../../dependencies/DSAuth.sol";

--- a/src/fund/policies/risk-management/AssetBlacklist.sol
+++ b/src/fund/policies/risk-management/AssetBlacklist.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../AddressList.sol";

--- a/src/fund/policies/risk-management/AssetWhitelist.sol
+++ b/src/fund/policies/risk-management/AssetWhitelist.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../AddressList.sol";

--- a/src/fund/policies/risk-management/MaxConcentration.sol
+++ b/src/fund/policies/risk-management/MaxConcentration.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../TradingSignatures.sol";

--- a/src/fund/policies/risk-management/MaxPositions.sol
+++ b/src/fund/policies/risk-management/MaxPositions.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../hub/Spoke.sol";

--- a/src/fund/policies/risk-management/PriceTolerance.sol
+++ b/src/fund/policies/risk-management/PriceTolerance.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../TradingSignatures.sol";

--- a/src/fund/shares/IShares.sol
+++ b/src/fund/shares/IShares.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Shares Interface

--- a/src/fund/shares/Shares.sol
+++ b/src/fund/shares/Shares.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/fund/shares/SharesToken.sol
+++ b/src/fund/shares/SharesToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../../dependencies/token/StandardToken.sol";

--- a/src/fund/vault/IVault.sol
+++ b/src/fund/vault/IVault.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title Vault Interface

--- a/src/fund/vault/Vault.sol
+++ b/src/fund/vault/Vault.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/AirSwapAdapter.sol
+++ b/src/integrations/adapters/AirSwapAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/EngineAdapter.sol
+++ b/src/integrations/adapters/EngineAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/KyberAdapter.sol
+++ b/src/integrations/adapters/KyberAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/OasisDexAdapter.sol
+++ b/src/integrations/adapters/OasisDexAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/UniswapAdapter.sol
+++ b/src/integrations/adapters/UniswapAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/ZeroExV2Adapter.sol
+++ b/src/integrations/adapters/ZeroExV2Adapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/adapters/ZeroExV3Adapter.sol
+++ b/src/integrations/adapters/ZeroExV3Adapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/interfaces/IKyberNetworkProxy.sol
+++ b/src/integrations/interfaces/IKyberNetworkProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 

--- a/src/integrations/interfaces/IOasisDex.sol
+++ b/src/integrations/interfaces/IOasisDex.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @dev Minimal interface for our interactions with OasisDex MatchingMarket

--- a/src/integrations/interfaces/ISwap.sol
+++ b/src/integrations/interfaces/ISwap.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/interfaces/IUniswapExchange.sol
+++ b/src/integrations/interfaces/IUniswapExchange.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @dev Minimal interface for our interactions with UniswapExchange

--- a/src/integrations/interfaces/IUniswapFactory.sol
+++ b/src/integrations/interfaces/IUniswapFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @dev Minimal interface for our interactions with UniswapFactory

--- a/src/integrations/interfaces/IZeroExV2.sol
+++ b/src/integrations/interfaces/IZeroExV2.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/interfaces/IZeroExV3.sol
+++ b/src/integrations/interfaces/IZeroExV3.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/libs/IntegrationAdapter.sol
+++ b/src/integrations/libs/IntegrationAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/libs/OrderFiller.sol
+++ b/src/integrations/libs/OrderFiller.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/libs/OrderTaker.sol
+++ b/src/integrations/libs/OrderTaker.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/integrations/libs/decoders/MinimalTakeOrderDecoder.sol
+++ b/src/integrations/libs/decoders/MinimalTakeOrderDecoder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/prices/IDerivativePriceSource.sol
+++ b/src/prices/IDerivativePriceSource.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title IDerivativePriceSource Interface

--- a/src/prices/IPriceSource.sol
+++ b/src/prices/IPriceSource.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 /// @title PriceSource Interface

--- a/src/prices/KyberPriceFeed.sol
+++ b/src/prices/KyberPriceFeed.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "../dependencies/DSMath.sol";

--- a/src/registry/IRegistry.sol
+++ b/src/registry/IRegistry.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/registry/Registry.sol
+++ b/src/registry/Registry.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/src/requests/SharesRequestor.sol
+++ b/src/requests/SharesRequestor.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 pragma experimental ABIEncoderV2;
 

--- a/tests/contracts/BadERC20Token.sol
+++ b/tests/contracts/BadERC20Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "main/dependencies/SafeMath.sol";

--- a/tests/contracts/MaliciousToken.sol
+++ b/tests/contracts/MaliciousToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "main/dependencies/token/PreminedToken.sol";

--- a/tests/contracts/TestingPriceFeed.sol
+++ b/tests/contracts/TestingPriceFeed.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.8;
 
 import "main/dependencies/token/IERC20.sol";


### PR DESCRIPTION
It's now recommended practice to start a solidity file with the relevant license declaration in a comment. See https://solidity.readthedocs.io/en/latest/layout-of-source-files.html?highlight=license#spdx-license-identifier

@travs Should be super easy to glance over, just need to confirm that GPL-3.0 is definitely the license we're going with.