### PR TITLE
feat: restrict updating melon council accounts used for access control

### DIFF
--- a/migrations/14_post_deployment.js
+++ b/migrations/14_post_deployment.js
@@ -1,5 +1,4 @@
 const mainnetAddrs = require('../config');
-const Registry = artifacts.require('Registry');
 const OasisDex = artifacts.require('IOasisDex');
 const WETH = artifacts.require('WETH');
 const MLN = artifacts.require('MLN');
@@ -42,9 +41,6 @@ module.exports = async _ => {
   await zrx.transfer(primary, web3.utils.toWei('1000', 'ether'), {from: mainnetAddrs.whales.ZRX});
   await zrx.transfer(manager, web3.utils.toWei('1000', 'ether'), {from: mainnetAddrs.whales.ZRX});
   await zrx.transfer(investor, web3.utils.toWei('1000', 'ether'), {from: mainnetAddrs.whales.ZRX});
-
-  const registry = await Registry.deployed();
-  await registry.setOwner(mainnetAddrs.melon.MelonRegistryOwner);
 
   const oasisDex = await OasisDex.at(mainnetAddrs.oasis.OasisDexExchange);
   await oasisDex.setMatchingEnabled(false, {

--- a/migrations/6_deploy_registry.js
+++ b/migrations/6_deploy_registry.js
@@ -6,10 +6,11 @@ const WETH = artifacts.require('WETH');
 const MLN = artifacts.require('MLN');
 
 module.exports = async (deployer, _, [admin]) => {
-  await deployer.deploy(Registry, admin);
+  // TODO: 1st param should be real MTC
+  // TODO: 2nd param should be real MGM
+  await deployer.deploy(Registry, admin, mainnetAddrs.melon.MelonInitialMGM);
 
   const registry = await Registry.deployed();
-  await registry.setMGM(mainnetAddrs.melon.MelonInitialMGM);
 
   const weth = await WETH.at(mainnetAddrs.tokens.WETH);
   const mln = await MLN.at(mainnetAddrs.tokens.MLN);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@0x/types-v2": "npm:@0x/types@2.4.3",
     "@0x/utils": "^5.1.2",
     "@airswap/order-utils": "^0.3.20",
+    "@openzeppelin/contracts": "3.0.1",
     "ganache-core": "^2.11.0-beta.0",
     "jest": "^26.1.0",
     "jest-matcher-utils": "^26.1.0",

--- a/src/registry/utils/MelonCouncilOwnable.sol
+++ b/src/registry/utils/MelonCouncilOwnable.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+import "../../../node_modules/@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title MelonCouncilOwnable Contract
+/// @author Melon Council DAO <security@meloncoucil.io>
+/// @notice A base contract for ownership of Melon's top-level contract,
+/// which ensures Melon Council control after setup
+contract MelonCouncilOwnable is Ownable {
+    address immutable public MGM;
+    address immutable public MTC;
+
+    constructor(address _MTC, address _MGM) public {
+        MTC = _MTC;
+        MGM = _MGM;
+    }
+
+    /// @notice Renounces ownership of the contract (NOT ALLOWED)
+    /// @dev Ownership cannot be destroyed
+    function renounceOwnership() public override {
+        revert("renounceOwnership: Renouncing ownership not allowed");
+    }
+
+    /// @notice Transfers ownership of the contract
+    /// @param _newOwner The new contract owner
+    /// @dev Ownership is only transferrable until the MTC receives ownership.
+    /// After that, ownership is no longer transferrable. This is desirable so
+    /// that Melon developers can do the time-consuming work of deploying and
+    /// configuring a contract, before giving custody of it to the Melon Council
+    function transferOwnership(address _newOwner) public override onlyOwner {
+        require(MTC != owner(), "transferOwnership: MTC cannot transfer ownership");
+        super.transferOwnership(_newOwner);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,11 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
   integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
 
+"@openzeppelin/contracts@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.0.1.tgz#2f327f77d16b43f14674086b2b634bda38cb0838"
+  integrity sha512-uSrD7hZ0ViuHGqHZbeHawZBi/uy7aBiNramXAt2dFFuSuoU4u9insS3V3zdVfOnYSPreUo636xSOuQIFN4//HA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
This PR replaces DSAuth in the `Registry` with a `MelonCouncilOwnable` contract, a slightly modified child of OpenZeppelin's `Ownable` contract.

- `MTC` and `MGM` are `immutable` vars on the new contract, defined in the `constructor()`, and are then unchangable
- The contract owner is initially its deployer, and ownership can be transferred, but only until `MTC` and `_owner` are the same.
- Relinquishing ownership is prohibited.
- This assures that once the MTC has ownership of the contract, they will forever be the owner.