### PR TITLE
refactor: FundFactory adds Fund to Registry with required unique name

### DIFF
--- a/src/registry/IRegistry.sol
+++ b/src/registry/IRegistry.sol
@@ -27,6 +27,6 @@ interface IRegistry {
     function nativeAsset() external view returns(address);
     function owner() external view returns(address);
     function priceSource() external view returns(address);
-    function registerFund(address _fund, address _owner) external;
+    function registerFund(address, address, bytes32) external;
     function sharesRequestor() external view returns(address);
 }


### PR DESCRIPTION
Just a simple PR I split off from #986 , as it is not related to the the main objective of that PR.

Enforces unique fund naming in the `Registry`, and allows any known `FundFactory` to register funds (e.g., in case a fund starts the fund deployment process with `FundFactory A` and then `FundFactory B` is deployed and becomes the most recent FundFactory).