### PR TITLE
feat: Uniswap v2 adapter - trading only

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,9 @@ module.exports = {
   uniswap: {
     UniswapFactory: '0xc0a47dFe034B400B47bDaD5FecDa2621de6c4d95'
   },
+  uniswapV2: {
+    UniswapV2Router2: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+  },
   zeroExV2: {
     ZeroExV2Exchange: '0x080bf510fcbf18b91105470639e9561022937712',
     ZeroExV2ERC20Proxy: '0x95e6f48254609a6ee006f7d493c8e5fb97094cef'

--- a/contracts/integrations/adapters/UniswapV2Adapter.sol
+++ b/contracts/integrations/adapters/UniswapV2Adapter.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+import "../interfaces/IUniswapV2Router2.sol";
+import "../utils/AdapterBase.sol";
+
+/// @title UniswapAdapter Contract
+/// @author Melon Council DAO <security@meloncoucil.io>
+/// @notice Adapter for interacting with Uniswap v2
+contract UniswapV2Adapter is AdapterBase {
+    address immutable public ROUTER;
+
+    constructor(address _registry, address _router) public AdapterBase(_registry) {
+        ROUTER = _router;
+    }
+
+    // EXTERNAL FUNCTIONS
+
+    /// @notice Provides a constant string identifier for an adapter
+    /// @return An identifier string
+    function identifier() external pure override returns (string memory) {
+        return "UNISWAP_V2";
+    }
+
+    /// @notice Parses the expected assets to receive from a call on integration 
+    /// @param _selector The function selector for the callOnIntegration
+    /// @param _encodedCallArgs The encoded parameters for the callOnIntegration
+    /// @return spendAssets_ The assets to spend in the call
+    /// @return spendAssetAmounts_ The max asset amounts to spend in the call
+    /// @return incomingAssets_ The assets to receive in the call
+    /// @return minIncomingAssetAmounts_ The min asset amounts to receive in the call
+    function parseAssetsForMethod(bytes4 _selector, bytes calldata _encodedCallArgs)
+        external
+        view
+        override
+        returns (
+            address[] memory spendAssets_,
+            uint256[] memory spendAssetAmounts_,
+            address[] memory incomingAssets_,
+            uint256[] memory minIncomingAssetAmounts_
+        )
+    {
+        if (_selector == TAKE_ORDER_SELECTOR) {
+            (
+                address[] memory path,
+                uint256 minIncomingAssetAmount,
+                uint256 outgoingAssetAmount
+            ) = __decodeCallArgs(_encodedCallArgs);
+
+            spendAssets_ = new address[](1);
+            spendAssets_[0] = path[0];
+            spendAssetAmounts_ = new uint256[](1);
+            spendAssetAmounts_[0] = outgoingAssetAmount;
+
+            incomingAssets_ = new address[](1);
+            incomingAssets_[0] = path[path.length - 1];
+            minIncomingAssetAmounts_ = new uint256[](1);
+            minIncomingAssetAmounts_[0] = minIncomingAssetAmount;
+        }
+        else {
+            revert("parseIncomingAssets: _selector invalid");
+        }
+    }
+
+    /// @notice Trades assets on Uniswap
+    /// @param _encodedCallArgs Encoded order parameters
+    /// @param _encodedAssetTransferArgs Encoded args for expected assets to spend and receive
+    function takeOrder(bytes calldata _encodedCallArgs, bytes calldata _encodedAssetTransferArgs)
+        external
+        onlyVault
+        fundAssetsTransferHandler(_encodedAssetTransferArgs)
+    {
+        (
+            address[] memory path,
+            uint256 minIncomingAssetAmount,
+            uint256 outgoingAssetAmount
+        ) = __decodeCallArgs(_encodedCallArgs);
+
+        // Validate args
+        require(path.length >= 2, "takeOrder: path must be >=2");
+        require(minIncomingAssetAmount > 0, "takeOrder: minIncomingAssetAmount must be >0");
+        require(outgoingAssetAmount > 0, "takeOrder: outgoingAssetAmount must be >0");
+
+        // Execute fill
+        IERC20(path[0]).approve(ROUTER, outgoingAssetAmount);
+        IUniswapV2Router2(ROUTER).swapExactTokensForTokens(
+            outgoingAssetAmount,
+            minIncomingAssetAmount,
+            path,
+            msg.sender,
+            add(block.timestamp, 1)
+        );
+    }
+
+    // PRIVATE FUNCTIONS
+
+    /// @dev Helper to decode the encoded arguments
+    function __decodeCallArgs(bytes memory _encodedCallArgs)
+        private
+        pure
+        returns (
+            address[] memory path_,
+            uint256 minIncomingAssetAmount_,
+            uint256 outgoingAssetAmount_
+        )
+    {
+        return abi.decode(
+            _encodedCallArgs,
+            (
+                address[],
+                uint256,
+                uint256
+            )
+        );
+    }
+}

--- a/contracts/integrations/interfaces/IUniswapV2Router2.sol
+++ b/contracts/integrations/interfaces/IUniswapV2Router2.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+/// @dev Minimal interface for our interactions with Uniswap V2's Router2
+interface IUniswapV2Router2 {
+    function swapExactTokensForTokens(uint256, uint256, address[] calldata, address, uint256)
+        external
+        returns (uint256[] memory);
+
+    // Used for testing only
+    function getAmountsOut(uint256, address[] calldata) external view returns (uint256[] memory);
+}

--- a/migrations/11_deploy_adapters.js
+++ b/migrations/11_deploy_adapters.js
@@ -1,6 +1,7 @@
 const KyberAdapter = artifacts.require('KyberAdapter');
 const OasisDexAdapter = artifacts.require('OasisDexAdapter');
 const UniswapAdapter = artifacts.require('UniswapAdapter');
+const UniswapV2Adapter = artifacts.require('UniswapV2Adapter');
 const ZeroExV2Adapter = artifacts.require('ZeroExV2Adapter');
 const ZeroExV3Adapter = artifacts.require('ZeroExV3Adapter');
 const EngineAdapter = artifacts.require('EngineAdapter');
@@ -16,6 +17,7 @@ module.exports = async deployer => {
   await deployer.deploy(KyberAdapter, registryAddress, mainnetAddrs.kyber.KyberNetworkProxy);
   await deployer.deploy(OasisDexAdapter, registryAddress, mainnetAddrs.oasis.OasisDexExchange);
   await deployer.deploy(UniswapAdapter, registryAddress, mainnetAddrs.uniswap.UniswapFactory);
+  await deployer.deploy(UniswapV2Adapter, registryAddress, mainnetAddrs.uniswapV2.UniswapV2Router2);
   await deployer.deploy(ZeroExV2Adapter, registryAddress, mainnetAddrs.zeroExV2.ZeroExV2Exchange);
   await deployer.deploy(ZeroExV3Adapter, registryAddress, mainnetAddrs.zeroExV3.ZeroExV3Exchange);
   await deployer.deploy(AirSwapAdapter, registryAddress, mainnetAddrs.airSwap.AirSwapSwap);

--- a/migrations/12_configure_registry.js
+++ b/migrations/12_configure_registry.js
@@ -16,6 +16,7 @@ const PriceTolerance = artifacts.require('PriceTolerance');
 const Registry = artifacts.require('Registry');
 const SharesRequestor = artifacts.require('SharesRequestor');
 const UniswapAdapter = artifacts.require('UniswapAdapter');
+const UniswapV2Adapter = artifacts.require('UniswapV2Adapter');
 const UserWhitelist = artifacts.require('UserWhitelist');
 const ValueInterpreter = artifacts.require('ValueInterpreter');
 const ZeroExV2Adapter = artifacts.require('ZeroExV2Adapter');
@@ -57,6 +58,7 @@ module.exports = async _ => {
     (await KyberAdapter.deployed()).address,
     (await OasisDexAdapter.deployed()).address,
     (await UniswapAdapter.deployed()).address,
+    (await UniswapV2Adapter.deployed()).address,
     (await ZeroExV2Adapter.deployed()).address,
     (await ZeroExV3Adapter.deployed()).address
   ];

--- a/tests/integration/fundUniswapV2Trading.test.js
+++ b/tests/integration/fundUniswapV2Trading.test.js
@@ -1,0 +1,241 @@
+/*
+ * @file Tests funds vault via the Uniswap V2 adapter
+ *
+ * @test Swap ERC20 for WETH (with minimum set from Uniswap price)
+ * @test Swap WETH for ERC20 (with minimum set from Uniswap price)
+ * @test Swap ERC20 for ERC20 (with no minimum set)
+ * @test Swap fails if minimum is not met
+ */
+
+import { BN, toWei } from 'web3-utils';
+import { call, send } from '~/utils/deploy-contract';
+import { CALL_ON_INTEGRATION_ENCODING_TYPES, CONTRACT_NAMES } from '~/utils/constants';
+import { setupFundWithParams } from '~/utils/fund';
+import { getFunctionSignature } from '~/utils/metadata';
+import { encodeArgs } from '~/utils/formatting';
+import { getDeployed } from '~/utils/getDeployed';
+import mainnetAddrs from '~/config';
+
+let deployer, manager, investor;
+let defaultTxOpts, managerTxOpts;
+let zrx, mln, weth, fund;
+let mlnExchange, zrxExchange;
+let takeOrderSignature;
+let uniswapAdapter;
+let uniswapRouter2;
+
+beforeAll(async () => {
+  [deployer, manager, investor] = await web3.eth.getAccounts();
+  defaultTxOpts = { from: deployer, gas: 8000000 };
+  managerTxOpts = { ...defaultTxOpts, from: manager };
+
+  takeOrderSignature = getFunctionSignature(
+    CONTRACT_NAMES.UNISWAP_ADAPTER,
+    'takeOrder',
+  );
+
+  mln = getDeployed(CONTRACT_NAMES.ERC20_WITH_FIELDS, mainnetAddrs.tokens.MLN);
+  weth = getDeployed(CONTRACT_NAMES.WETH, mainnetAddrs.tokens.WETH);
+  zrx = getDeployed(CONTRACT_NAMES.ERC20_WITH_FIELDS, mainnetAddrs.tokens.ZRX);
+  const fundFactory = getDeployed(CONTRACT_NAMES.FUND_FACTORY);
+  uniswapAdapter = getDeployed(CONTRACT_NAMES.UNISWAP_V2_ADAPTER);
+  uniswapRouter2 = getDeployed(
+    CONTRACT_NAMES.UNISWAP_V2_ROUTER2_INTERFACE,
+    mainnetAddrs.uniswapV2.UniswapV2Router2
+  );
+
+  fund = await setupFundWithParams({
+    integrationAdapters: [uniswapAdapter.options.address],
+    initialInvestment: {
+      contribAmount: toWei('1', 'ether'),
+      investor,
+      tokenContract: weth
+    },
+    manager,
+    quoteToken: weth.options.address,
+    fundFactory
+  });
+});
+
+test('Swap WETH for MLN with minimum derived from Uniswap price', async () => {
+  const { vault } = fund;
+
+  const outgoingAsset = weth.options.address;
+  const outgoingAssetAmount = toWei('0.1', 'ether');
+  const incomingAsset = mln.options.address;
+  const path = [outgoingAsset, incomingAsset];
+  const { 1: expectedIncomingAssetAmount } = await call(
+    uniswapRouter2,
+    'getAmountsOut',
+    [outgoingAssetAmount, path]
+  );
+
+  const encodedArgs = encodeArgs(
+    CALL_ON_INTEGRATION_ENCODING_TYPES.UNISWAP_V2.TAKE_ORDER,
+    [
+      path, // "path" from outgoing asset to incoming asset, including intermediaries
+      expectedIncomingAssetAmount, // min incoming asset amount
+      outgoingAssetAmount // exact outgoing asset amount
+    ]
+  );
+
+  const preFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const preFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+
+  await send(
+    vault,
+    'callOnIntegration',
+    [
+      uniswapAdapter.options.address,
+      takeOrderSignature,
+      encodedArgs,
+    ],
+    managerTxOpts
+  );
+
+  const postFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const postFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+
+  const fundBalanceOfWethDiff = preFundBalanceOfWeth.sub(postFundBalanceOfWeth);
+  const fundBalanceOfMlnDiff = postFundBalanceOfMln.sub(preFundBalanceOfMln);
+
+  // Confirm that expected asset amounts were filled
+  expect(fundBalanceOfWethDiff).bigNumberEq(new BN(outgoingAssetAmount));
+  expect(fundBalanceOfMlnDiff).bigNumberEq(new BN(expectedIncomingAssetAmount));
+});
+
+test('Swap MLN for WETH with minimum derived from Uniswap price', async () => {
+  const { vault } = fund;
+
+  const outgoingAsset = mln.options.address;
+  const outgoingAssetAmount = toWei('0.01', 'ether');
+  const incomingAsset = weth.options.address;
+  const path = [outgoingAsset, incomingAsset];
+  const { 1: expectedIncomingAssetAmount } = await call(
+    uniswapRouter2,
+    'getAmountsOut',
+    [outgoingAssetAmount, path]
+  );
+
+  const encodedArgs = encodeArgs(
+    CALL_ON_INTEGRATION_ENCODING_TYPES.UNISWAP_V2.TAKE_ORDER,
+    [
+      path, // "path" from outgoing asset to incoming asset, including intermediaries
+      expectedIncomingAssetAmount, // min incoming asset amount
+      outgoingAssetAmount // exact outgoing asset amount
+    ]
+  );
+
+  const preFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const preFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+
+  await send(
+    vault,
+    'callOnIntegration',
+    [
+      uniswapAdapter.options.address,
+      takeOrderSignature,
+      encodedArgs,
+    ],
+    managerTxOpts
+  );
+
+  const postFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const postFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+
+  const fundBalanceOfWethDiff = postFundBalanceOfWeth.sub(preFundBalanceOfWeth);
+  const fundBalanceOfMlnDiff = preFundBalanceOfMln.sub(postFundBalanceOfMln);
+
+  // Confirm that expected asset amounts were filled
+  expect(fundBalanceOfWethDiff).bigNumberEq(new BN(expectedIncomingAssetAmount));
+  expect(fundBalanceOfMlnDiff).bigNumberEq(new BN(outgoingAssetAmount));
+});
+
+test('Swap MLN directly to ZRX via WETH without specifying a minimum maker quantity', async () => {
+  const { vault } = fund;
+
+  const outgoingAsset = mln.options.address;
+  const outgoingAssetAmount = toWei('0.01', 'ether');
+  const incomingAsset = zrx.options.address;
+  const intermediateAsset = weth.options.address;
+  const path = [outgoingAsset, intermediateAsset, incomingAsset];
+  const { 2: expectedIncomingAssetAmount } = await call(
+    uniswapRouter2,
+    'getAmountsOut',
+    [outgoingAssetAmount, path]
+  );
+
+  const encodedArgs = encodeArgs(
+    CALL_ON_INTEGRATION_ENCODING_TYPES.UNISWAP_V2.TAKE_ORDER,
+    [
+      path, // "path" from outgoing asset to incoming asset, including intermediaries
+      1, // min incoming asset amount
+      outgoingAssetAmount // exact outgoing asset amount
+    ]
+  );
+
+  const preFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const preFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+  const preFundBalanceOfEur = new BN(await call(zrx, 'balanceOf', [vault.options.address]));
+
+  await send(
+    vault,
+    'callOnIntegration',
+    [
+      uniswapAdapter.options.address,
+      takeOrderSignature,
+      encodedArgs,
+    ],
+    managerTxOpts
+  );
+
+  const postFundBalanceOfWeth = new BN(await call(weth, 'balanceOf', [vault.options.address]));
+  const postFundBalanceOfMln = new BN(await call(mln, 'balanceOf', [vault.options.address]));
+  const postFundBalanceOfEur = new BN(await call(zrx, 'balanceOf', [vault.options.address]));
+
+  const fundBalanceOfWethDiff = preFundBalanceOfWeth.sub(postFundBalanceOfWeth);
+  const fundBalanceOfMlnDiff = preFundBalanceOfMln.sub(postFundBalanceOfMln);
+  const fundBalanceOfEurDiff = postFundBalanceOfEur.sub(preFundBalanceOfEur);
+
+  // Confirm that expected asset amounts were filled
+  expect(fundBalanceOfEurDiff).bigNumberEq(new BN(expectedIncomingAssetAmount));
+  expect(fundBalanceOfMlnDiff).bigNumberEq(new BN(outgoingAssetAmount));
+  expect(fundBalanceOfWethDiff).bigNumberEq(new BN(0));
+});
+
+test('Order fails if maker amount is not satisfied', async () => {
+  const { vault } = fund;
+
+  const outgoingAsset = mln.options.address;
+  const outgoingAssetAmount = toWei('0.01', 'ether');
+  const incomingAsset = weth.options.address;
+  const path = [outgoingAsset, incomingAsset];
+  const { 1: expectedIncomingAssetAmount } = await call(
+    uniswapRouter2,
+    'getAmountsOut',
+    [outgoingAssetAmount, path]
+  );
+  const tooHighIncomingAssetAmount = new BN(expectedIncomingAssetAmount).add(new BN(1)).toString();
+
+  const encodedArgs = encodeArgs(
+    CALL_ON_INTEGRATION_ENCODING_TYPES.UNISWAP_V2.TAKE_ORDER,
+    [
+      path, // "path" from outgoing asset to incoming asset, including intermediaries
+      tooHighIncomingAssetAmount, // min incoming asset amount
+      outgoingAssetAmount // exact outgoing asset amount
+    ]
+  );
+  
+  await expect(
+    send(
+      vault,
+      'callOnIntegration',
+      [
+        uniswapAdapter.options.address,
+        takeOrderSignature,
+        encodedArgs,
+      ],
+      managerTxOpts
+    )
+  ).rejects.toThrow(); // No specific message, fails at Uniswap level
+});

--- a/tests/utils/constants.js
+++ b/tests/utils/constants.js
@@ -59,6 +59,13 @@ export const CALL_ON_INTEGRATION_ENCODING_TYPES = {
       'uint256' // exact outgoing asset amount
     ]
   },
+  UNISWAP_V2: {
+    TAKE_ORDER: [
+      'address[]', // "path" from outgoing asset to incoming asset, incl any intermediary steps
+      'uint256', // min incoming asset amount
+      'uint256' // exact outgoing asset amount
+    ]
+  },
   ZERO_EX_V2: {
     TAKE_ORDER: [
       'bytes', // ZERO_EX_V2.ORDER
@@ -165,6 +172,8 @@ export const CONTRACT_NAMES = {
   UNISWAP_EXCHANGE: 'UniswapExchange',
   UNISWAP_EXCHANGE_INTERFACE: 'IUniswapExchange',
   UNISWAP_EXCHANGE_TEMPLATE: 'UniswapExchangeTemplate',
+  UNISWAP_V2_ADAPTER: 'UniswapV2Adapter',
+  UNISWAP_V2_ROUTER2_INTERFACE: 'IUniswapV2Router2',
   AIR_SWAP_SWAP: 'AirSwapSwap',
   AIR_SWAP_TYPES: 'AirSwapTypes',
   AIR_SWAP_ADAPTER: 'AirSwapAdapter',


### PR DESCRIPTION
This PR introduces an adapter for making swaps on Uniswap v2. It does not include interacting with liquidity pool liquidity.