### PR TITLE
fix: kyber pricefeed missing functions

### DIFF
--- a/src/prices/KyberPriceFeed.sol
+++ b/src/prices/KyberPriceFeed.sol
@@ -19,7 +19,7 @@ contract KyberPriceFeed is DSMath {
     uint32 public constant VALIDITY_INTERVAL = 2 days;
     address public KYBER_NETWORK_PROXY;
     address public QUOTE_ASSET;
-    uint256 public lastUpdate;
+    uint256 private lastUpdate;
     uint256 public maxPriceDeviation; // percent, expressed as a uint256 (fraction of 10^18)
     uint256 public maxSpread;
     address public updater;
@@ -160,6 +160,12 @@ contract KyberPriceFeed is DSMath {
             }
         }
         return true;
+    }
+
+    /// @notice Returns timestamp of the last successful pricefeed update
+    /// @return The timestamp of the last successful pricefeed update
+    function getLastUpdate() external view returns (uint256) {
+        return lastUpdate;
     }
 
     /// @notice Returns price as determined by an order

--- a/src/prices/KyberPriceFeed.sol
+++ b/src/prices/KyberPriceFeed.sol
@@ -12,7 +12,7 @@ contract KyberPriceFeed is DSMath {
     event ExpectedRateWethQtySet(uint256 expectedRateWethQty);
     event MaxPriceDeviationSet(uint256 maxPriceDeviation);
     event MaxSpreadSet(uint256 maxSpread);
-    event PricesUpdated(address[] assets, uint256[] prices);
+    event PriceUpdate(address[] assets, uint256[] prices);
     event RegistrySet(address newRegistry);
     event UpdaterSet(address updater);
 
@@ -99,7 +99,7 @@ contract KyberPriceFeed is DSMath {
             prices[_saneAssets[i]] = newPrices[i];
         }
         lastUpdate = block.timestamp;
-        emit PricesUpdated(_saneAssets, newPrices);
+        emit PriceUpdate(_saneAssets, newPrices);
     }
 
     /// @notice Update the srcQty to use in getExpectedRate(), in terms of WETH

--- a/tests/unit/feed/kyberPriceFeed.test.js
+++ b/tests/unit/feed/kyberPriceFeed.test.js
@@ -2,7 +2,7 @@
  * @file Tests simple cases of updating price against a Kyber deployment
  *
  * @test Some unrelated account cannot update feed
- * @test Registy owner an update feed
+ * @test Registry owner an update feed
  * @test Delegated updater can update the feed
  * @test MLN price update on reserve changes price on feed post-update
  * @test Normal spread condition from Kyber rates yields midpoint price
@@ -76,7 +76,9 @@ describe('update', () => {
         kyberNetworkProxy.options.address,
         toWei('0.5', 'ether'),
         weth.options.address,
-        toWei('0.1', 'ether')
+        toWei('0.1', 'ether'),
+        toWei('0.1', 'ether'),
+        deployer
       ],
       deployerTxOpts
     );
@@ -96,7 +98,7 @@ describe('update', () => {
       send(
         kyberPriceFeed,
         'update',
-        [registeredAssets, dummyPrices, false],
+        [registeredAssets, dummyPrices],
         someAccountTxOpts
       )
     ).rejects.toThrowFlexible('Only registry owner or updater can call');
@@ -110,11 +112,11 @@ describe('update', () => {
     let receipt = await send(
       kyberPriceFeed,
       'update',
-      [registeredAssets, dummyPrices, false],
+      [registeredAssets, dummyPrices],
       deployerTxOpts
     );
     const logUpdated = getEventFromLogs(
-        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PricesUpdated'
+        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PriceUpdate'
     );
 
     expect(logUpdated.assets).toEqual(registeredAssets);
@@ -126,7 +128,7 @@ describe('update', () => {
       send(
         kyberPriceFeed,
         'update',
-        [registeredAssets, dummyPrices, false],
+        [registeredAssets, dummyPrices],
         updaterTxOpts
       )
     ).rejects.toThrowFlexible('Only registry owner or updater can call');
@@ -141,11 +143,11 @@ describe('update', () => {
     receipt = await send(
       kyberPriceFeed,
       'update',
-      [registeredAssets, dummyPrices, false],
+      [registeredAssets, dummyPrices],
       updaterTxOpts
     );
     const logUpdated = getEventFromLogs(
-        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PricesUpdated'
+        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PriceUpdate'
     );
 
     expect(logUpdated.assets).toEqual(registeredAssets);
@@ -174,8 +176,7 @@ describe('update', () => {
             toWei('1', 'ether'),
             barelyTooHighMlnPrice.toString(),
             toWei('1', 'ether')
-          ],
-          false
+          ]
         ],
         deployerTxOpts
       )
@@ -190,14 +191,13 @@ describe('update', () => {
           toWei('1', 'ether'),
           upperEndValidMlnPrice.toString(),
           toWei('1', 'ether')
-        ],
-        false
+        ]
       ],
       deployerTxOpts
     );
 
     const logUpdated = getEventFromLogs(
-        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PricesUpdated'
+        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PriceUpdate'
     );
 
     expect(logUpdated.assets).toEqual(registeredAssets);
@@ -224,8 +224,7 @@ describe('update', () => {
             toWei('1', 'ether'),
             barelyTooLowMlnPrice.toString(),
             toWei('1', 'ether')
-          ],
-          false
+          ]
         ],
         deployerTxOpts
       )
@@ -240,14 +239,13 @@ describe('update', () => {
           toWei('1', 'ether'),
           lowerEndValidMlnPrice.toString(),
           toWei('1', 'ether')
-        ],
-        false
+        ]
       ],
       deployerTxOpts
     );
 
     const logUpdated = getEventFromLogs(
-        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PricesUpdated'
+        receipt.logs, CONTRACT_NAMES.KYBER_PRICEFEED, 'PriceUpdate'
     );
 
     expect(logUpdated.assets).toEqual(registeredAssets);
@@ -295,7 +293,6 @@ describe('update', () => {
       ],
       deployerTxOpts
     );
-
     await send(
       kyberPriceFeed,
       'update',
@@ -305,8 +302,7 @@ describe('update', () => {
           toWei('1', 'ether'),
           midpointPrice.toString(),
           toWei('1', 'ether')
-        ],
-        true
+        ]
       ],
       deployerTxOpts
     );
@@ -346,30 +342,11 @@ describe('update', () => {
             toWei('1', 'ether'),
             midpointPrice.toString(),
             toWei('1', 'ether')
-          ],
-          true
+          ]
         ],
         deployerTxOpts
       )
     ).rejects.toThrowFlexible('update: Aborting due to invalid price');
-
-    await send(
-      kyberPriceFeed,
-      'update',
-      [
-        registeredAssets,
-        [
-          toWei('1', 'ether'),
-          midpointPrice.toString(),
-          toWei('1', 'ether')
-        ],
-        false
-      ],
-      deployerTxOpts
-    );
-
-    const validPricePostUpdate2 = await call(kyberPriceFeed, 'hasValidPrice', [mln.options.address]);
-    expect(validPricePostUpdate2).toBe(false);
   });
 });
 
@@ -384,7 +361,9 @@ describe('getPrice', () => {
         kyberNetworkProxy.options.address,
         toWei('0.5', 'ether'),
         weth.options.address,
-        toWei('0.1', 'ether')
+        toWei('0.1', 'ether'),
+        toWei('0.1', 'ether'),
+        deployer
       ],
       deployerTxOpts
     );
@@ -427,8 +406,7 @@ describe('getPrice', () => {
           eurPrice.toString(),
           mlnPrice.toString(),
           toWei('1', 'ether')
-        ],
-        false
+        ]
       ],
       deployerTxOpts
     );
@@ -480,8 +458,7 @@ describe('getPrice', () => {
           preEurPrice.price_.toString(),
           midpointPrice.toString(),
           toWei('1', 'ether')
-        ],
-        false
+        ]
       ],
       deployerTxOpts
     );
@@ -530,8 +507,7 @@ describe('getPrice', () => {
           preEurPrice.price_.toString(),
           midpointPrice,
           toWei('1', 'ether')
-        ],
-        false
+        ]
       ],
       deployerTxOpts
     );


### PR DESCRIPTION
The primary purpose of this PR is to re-implement a function that is defined in `IPriceSource.sol` and is used in `Participation.sol`, but is missing from `KyberPriceFeed.sol`, which caused the price feed to be unusable.

Additionally, it:
- makes `KyberPriceFeed.sol` inherit from `IPriceSource.sol`, and re-implements all other missing functions (even though these other functions are not used in the protocol codebase)
- reverts name of an event to its old name, to be consistent with the production version of the Melon subgraph
- replaces `_failIfInvalid` flag on `update()` with check that allows a 0 price to pass if the sanity rate (i.e., its expected off-chain rate) is exactly 0 (e.g., SAI does not have a Kyber reserve price, but it is in the list of registered assets)
- replaces the use of arbitrary `reserveMin` values in passing a `srcQty` to `KyberNetworkProxy.getExpectedRate()` with dynamic calculations of the src asset relative to a constant amount of weth (e.g., 0.01 WETH worth of DAI, 0.01 WETH worth of WBTC, etc).