### PR TITLE
fix: correctly increase return value in derivative value calculation

### DIFF
--- a/contracts/prices/ValueInterpreter.sol
+++ b/contracts/prices/ValueInterpreter.sol
@@ -123,7 +123,7 @@ contract ValueInterpreter is IValueInterpreter, DSMath {
             ) = __calcAssetValue(underlyings[i], underlyingAmount, _quoteAsset, _useLiveRate);
 
             if (!underlyingIsValid) isValid_ = false;
-            add(value_, underlyingValue);
+            value_ = add(value_, underlyingValue);
         }
     }
 


### PR DESCRIPTION
Quick fix, not actually re-assigning the increased return value when looping through a derivative's underlying asset value conversions.