### PR TITLE
refactor: apply kyber price feed updates and tests

### DIFF
--- a/tests/contracts.ts
+++ b/tests/contracts.ts
@@ -39,3 +39,4 @@ export { ERC20 } from './codegen/ERC20';
 export { WETH } from './codegen/WETH';
 export { PreminedToken } from './codegen/PreminedToken';
 export { MockKyberIntegratee } from './codegen/MockKyberIntegratee';
+export { MockKyberPriceSource } from './codegen/MockKyberPriceSource';

--- a/tests/contracts/integratees/MockKyberIntegratee.sol
+++ b/tests/contracts/integratees/MockKyberIntegratee.sol
@@ -4,7 +4,9 @@ pragma solidity 0.6.8;
 import "./utils/MockIntegrateeBase.sol";
 
 contract MockKyberIntegratee is MockIntegrateeBase {
-    constructor() public MockIntegrateeBase(new address[](0), new uint8[](0), 18) {}
+    constructor(address[] memory _defaultRateAssets)
+        public
+        MockIntegrateeBase(_defaultRateAssets, new address[](0), new uint8[](0), 18) {}
 
     function swapEtherToToken(address _destToken, uint256)
         external

--- a/tests/contracts/integratees/utils/MockIntegrateeBase.sol
+++ b/tests/contracts/integratees/utils/MockIntegrateeBase.sol
@@ -4,15 +4,42 @@ pragma solidity 0.6.8;
 import "../../utils/NormalizedRateProviderBase.sol";
 
 abstract contract MockIntegrateeBase is NormalizedRateProviderBase {
-
     constructor(
+        address[] memory _defaultRateAssets,
         address[] memory _specialAssets,
         uint8[] memory _specialAssetDecimals,
         uint256 _ratePrecision
     )
         public
-        NormalizedRateProviderBase(_specialAssets, _specialAssetDecimals, _ratePrecision)
+        NormalizedRateProviderBase(_defaultRateAssets, _specialAssets, _specialAssetDecimals, _ratePrecision)
     {}
+
+    function __getRate(address _baseAsset, address _quoteAsset)
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        // 1. Return constant if base asset is quote asset
+        if (_baseAsset == _quoteAsset) {
+            return 10 ** RATE_PRECISION;
+        }
+
+        // 2. Check for a direct rate
+        uint256 directRate = assetToAssetRate[_baseAsset][_quoteAsset];
+        if (directRate > 0) {
+            return directRate;
+        }
+
+        // 3. Check for inverse direct rate
+        uint256 iDirectRate = assetToAssetRate[_quoteAsset][_baseAsset];
+        if (iDirectRate > 0) {
+            return 10 ** (RATE_PRECISION.mul(2)).div(iDirectRate);
+        }
+
+        // 4. Else return 1
+        return 10 ** RATE_PRECISION;
+    }
 
     function __swap(
         address[] memory _assetsToIntegratee,

--- a/tests/contracts/priceSources/MockKyberPriceSource.sol
+++ b/tests/contracts/priceSources/MockKyberPriceSource.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.6.8;
+
+import "../utils/NormalizedRateProviderBase.sol";
+
+contract MockKyberPriceSource is NormalizedRateProviderBase {
+    uint256 constant public MOCK_SLIPPAGE_RATE = 97 * 10 ** 16;
+
+    constructor(address[] memory _defaultRateAssets)
+        public
+        NormalizedRateProviderBase(_defaultRateAssets, new address[](0), new uint8[](0), 18)
+    {}
+
+    function getExpectedRate(address _baseAsset, address _quoteAsset, uint256)
+        external
+        view
+        returns (uint256, uint256)
+    {
+        uint256 rate = __getRate(_baseAsset, _quoteAsset);
+        uint256 slippageRate = rate.mul(MOCK_SLIPPAGE_RATE).div(RATE_PRECISION);
+
+        return (rate, slippageRate);
+    }
+}

--- a/tests/contracts/utils/RateProviderBase.sol
+++ b/tests/contracts/utils/RateProviderBase.sol
@@ -32,6 +32,15 @@ abstract contract RateProviderBase {
         return decimals;
     }
 
+    function __getRate(address _baseAsset, address _quoteAsset)
+        internal
+        view
+        virtual
+        returns (uint256)
+    {
+        return assetToAssetRate[_baseAsset][_quoteAsset];
+    }
+
     function setRates(
         address[] calldata _baseAssets,
         address[] calldata _quoteAssets,

--- a/tests/tests/KyberPriceFeed.test.ts
+++ b/tests/tests/KyberPriceFeed.test.ts
@@ -1,0 +1,141 @@
+import { utils, BigNumber, BigNumberish } from 'ethers';
+import { BuidlerProvider } from '@crestproject/crestproject';
+import { configureTestDeployment } from '../deployment';
+
+let tx;
+
+function inverseNormalizedRate(rate: BigNumberish, precision: number = 18) {
+  return BigNumber.from(10).pow(BigNumber.from(precision).mul(2)).div(rate);
+}
+
+async function snapshot(provider: BuidlerProvider) {
+  const deployment = await configureTestDeployment()(provider);
+
+  return {
+    ...deployment,
+  };
+}
+
+describe('KyberPriceFeed', () => {
+  describe('constructor', () => {
+    it('sets initial storage vars', async () => {
+      const {
+        system: { kyberPriceFeed, registry },
+        config: {
+          pricefeeds: {
+            kyber: {
+              expectedRateWethQty,
+              kyberNetworkProxy,
+              maxPriceDeviation,
+              maxSpread,
+              quoteAsset,
+              updater,
+            },
+          },
+        },
+      } = await provider.snapshot(snapshot);
+
+      tx = kyberPriceFeed.KYBER_NETWORK_PROXY();
+      await expect(tx).resolves.toBe(kyberNetworkProxy);
+
+      tx = kyberPriceFeed.PRICE_FEED_QUOTE_ASSET();
+      await expect(tx).resolves.toBe(quoteAsset);
+
+      tx = kyberPriceFeed.registry();
+      await expect(tx).resolves.toBe(registry.address);
+
+      tx = kyberPriceFeed.expectedRateWethQty();
+      await expect(tx).resolves.toEqBigNumber(expectedRateWethQty);
+
+      tx = kyberPriceFeed.maxPriceDeviation();
+      await expect(tx).resolves.toEqBigNumber(maxPriceDeviation);
+
+      tx = kyberPriceFeed.maxSpread();
+      await expect(tx).resolves.toEqBigNumber(maxSpread);
+
+      tx = kyberPriceFeed.updater();
+      await expect(tx).resolves.toBe(updater);
+    });
+  });
+
+  describe('getLiveRate', () => {
+    it('returns invalid when spread is greater than maxSpread', async () => {
+      const {
+        system: { kyberPriceFeed },
+        config: {
+          mocks: {
+            priceSources: { kyber: kyberPriceSource },
+          },
+          tokens: { mln, dai },
+        },
+      } = await provider.snapshot(snapshot);
+
+      const maxSpread = await kyberPriceFeed.maxSpread();
+
+      // Get rate for dai quoted in mln
+
+      // Set backwards rate (ask) to 1 to simplify math
+      const askRate = utils.parseEther('1');
+      await kyberPriceSource.setRates([mln], [dai], [askRate]);
+
+      // Set the bid rate to be exactly the maxSpread
+      const desiredIBidRate = askRate
+        .mul(utils.parseEther('1'))
+        .div(utils.parseEther('1').sub(maxSpread));
+      const goodBidRate = inverseNormalizedRate(desiredIBidRate);
+      await kyberPriceSource.setRates([dai], [mln], [goodBidRate]);
+
+      tx = await kyberPriceFeed.getLiveRate(dai, mln);
+      expect(tx.isValid_).toBe(true);
+
+      // Decreasing the bid rate by 1 wei should make it invalid
+      await kyberPriceSource.setRates([dai], [mln], [goodBidRate.sub(1)]);
+      tx = await kyberPriceFeed.getLiveRate(dai, mln);
+      expect(tx.isValid_).toBe(false);
+    });
+  });
+
+  it('returns invalid when either bid or ask rate is 0', async () => {
+    const {
+      system: { kyberPriceFeed },
+      config: {
+        mocks: {
+          priceSources: { kyber: kyberPriceSource },
+        },
+        tokens: { mln, dai },
+      },
+    } = await provider.snapshot(snapshot);
+
+    const baseAsset = mln;
+    const quoteAsset = dai;
+
+    // Set bid rate to 0, expect invalid rate
+    await kyberPriceSource.setRates(
+      [baseAsset, quoteAsset],
+      [quoteAsset, baseAsset],
+      [utils.parseEther('0'), utils.parseEther('1')],
+    );
+    tx = await kyberPriceFeed.getLiveRate(baseAsset, quoteAsset);
+    expect(tx.isValid_).toBe(false);
+
+    // Set ask rate to 0, expect invalid rate
+    await kyberPriceSource.setRates(
+      [baseAsset, quoteAsset],
+      [quoteAsset, baseAsset],
+      [utils.parseEther('1'), utils.parseEther('0')],
+    );
+    tx = await kyberPriceFeed.getLiveRate(baseAsset, quoteAsset);
+    expect(tx.isValid_).toBe(false);
+
+    // Start both rates to 1, expect a valid rate
+    await kyberPriceSource.setRates(
+      [baseAsset, quoteAsset],
+      [quoteAsset, baseAsset],
+      [utils.parseEther('1'), utils.parseEther('1')],
+    );
+    tx = await kyberPriceFeed.getLiveRate(baseAsset, quoteAsset);
+    expect(tx.isValid_).toBe(true);
+  });
+
+  it.todo('continue writing tests!');
+});


### PR DESCRIPTION
1. Apply the same updates that we're using for the master PR to Kyber price feed, plus use immutable vars
2. Add a `MockKyberPriceSource` contract and refactor other mock rate provider contracts to be flexible to meet the needs of all rate providers.
3. Add the beginnings of a kyber price feed test.