### PR TITLE
chore: prettier and solhint formatting and linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 !.prettierignore
 !.prettierrc
 !.travis.yml
+!.solhint.json
+!.solhintignore
 
 # ignore build output and dependencies
 artifacts/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@
 codegen/
 package/
 artifacts/
+
+# TODO: Re-enable this once contracts are formatted with prettier
+contracts/

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,18 @@
   "semi": true,
   "trailingComma": "all",
   "singleQuote": true,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 99,
+        "tabWidth": 4,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": false,
+        "explicitTypes": "always"
+      }
+    }
+  ]
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "solhint:recommended",
+  "rules": {
+    "compiler-version": ["error", "0.6.8"],
+    "no-empty-blocks": "off",
+    "not-rely-on-time": "off",
+    "avoid-low-level-calls": "off",
+    "no-inline-assembly": "off",
+    "var-name-mixedcase": "off",
+    "func-name-mixedcase": "off",
+    "reason-string": ["off"]
+  }
+}

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+contracts/dependencies/

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -1,5 +1,3 @@
-usePlugin('@nomiclabs/buidler-solhint');
-
 module.exports = {
   solc: {
     version: '0.6.8',

--- a/contracts/prices/ValueInterpreter.sol
+++ b/contracts/prices/ValueInterpreter.sol
@@ -78,12 +78,12 @@ contract ValueInterpreter is IValueInterpreter, DSMath {
         }
 
         // Else use derivative oracle to get value via underlying assets
-        else if (registry.derivativeToPriceSource(_baseAsset) != address(0)) {
+        if (registry.derivativeToPriceSource(_baseAsset) != address(0)) {
             return __calcDerivativeValue(_baseAsset, _amount, _quoteAsset, _useLiveRate);
         }
 
         // If not in Registry as an asset or derivative
-        else return (0, false);
+        return (0, false);
     }
 
     /// @notice Helper to covert from one asset to another with a given conversion rate

--- a/contracts/requests/SharesRequestor.sol
+++ b/contracts/requests/SharesRequestor.sol
@@ -207,8 +207,8 @@ contract SharesRequestor is DSMath, TokenUser, AmguConsumer, FundRouterMixin {
             // Return incentive to sender
             msg.sender.transfer(REGISTRY.incentive());
         }
-        // Create the Request and take custody of investment asset
         else {
+            // Create the Request and take custody of investment asset
             Request memory request = Request({
                 investmentAmount: _investmentAmount,
                 minSharesQuantity: _minSharesQuantity,

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "prepackage": "rimraf package",
     "package": "tsc && node scripts/package",
     "test": "yarn jest",
-    "format": "prettier --write \"tests/{*,**/*}.ts\"",
-    "lint": "prettier --list-different \"tests/{*,**/*}.ts\"",
-    "check": "yarn buidler check",
+    "format": "prettier --write \"{tests,contracts}/{*,**/*}.{sol,ts}\"",
+    "lint": "yarn lint:prettier && yarn lint:solhint",
+    "lint:prettier": "prettier --list-different \"{tests,contracts}/{*,**/*}.{sol,ts}\"",
+    "lint:solhint": "solhint \"tests/**/*.sol\" \"contracts/**/*.sol\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -41,13 +42,14 @@
   "devDependencies": {
     "@crestproject/crestproject": "^0.0.19",
     "@nomiclabs/buidler": "^1.4.3",
-    "@nomiclabs/buidler-solhint": "^1.3.3",
     "@types/jest": "^26.0.3",
     "ethers": "^5.0.5",
     "fs-extra": "^9.0.1",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",
+    "prettier-plugin-solidity": "^1.0.0-alpha.55",
     "rimraf": "^3.0.2",
+    "solhint": "^3.1.0",
     "ts-jest": "^26.1.4",
     "typescript": "^4.0.0-beta"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,13 +835,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@nomiclabs/buidler-solhint@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/buidler-solhint/-/buidler-solhint-1.3.3.tgz#cbe92b176e0e14054b7f60f609f412deacd1e3cb"
-  integrity sha512-bh7bGw4w8wDCdM1R3EoUnGww5GwxYzO7Q6O40B6kICb/eUU09hqRykSPoMdv/M30MduPS+UUduaJlwND+0L7IA==
-  dependencies:
-    solhint "^2.0.0"
-
 "@nomiclabs/buidler@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/buidler/-/buidler-1.4.3.tgz#4ac50d82830bd660fbd3b25ffd08e1d649da172e"
@@ -1018,6 +1011,11 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.5.2.tgz#4d74670ead39e4f4fdab605a393ba8ea2390a2c4"
   integrity sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==
+
+"@solidity-parser/parser@^0.6.0", "@solidity-parser/parser@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.6.2.tgz#49707fc4e06649d39d6b25bdab2e9093d372ce50"
+  integrity sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -1356,6 +1354,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-parents@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ast-parents/-/ast-parents-0.0.1.tgz#508fd0f05d0c48775d9eccda2e174423261e8dd3"
+  integrity sha1-UI/Q8F0MSHddnszaLhdEIyYejdM=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2280,6 +2283,11 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+dir-to-object@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-to-object/-/dir-to-object-2.0.0.tgz#29723e9bd1c3e58e4f307bd04ff634c0370c8f8a"
+  integrity sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2352,6 +2360,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.0.0.tgz#48a2309cc8a1d2e9d23bc6a67c39b63032e76ea4"
+  integrity sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==
 
 encoding-down@~5.0.0:
   version "5.0.4"
@@ -2427,6 +2440,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.14.1:
   version "1.14.3"
@@ -2510,6 +2528,13 @@ espree@^5.0.1:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+esprima-extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz#0dacab567a5900240de6d344cf18c33617becbc9"
+  integrity sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==
+  dependencies:
+    esprima "^4.0.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -2878,6 +2903,14 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/extract-comments/-/extract-comments-1.1.0.tgz#b90bca033a056bd69b8ba1c6b6b120fc2ee95c18"
+  integrity sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==
+  dependencies:
+    esprima-extract-comments "^1.1.0"
+    parse-code-context "^1.0.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -5253,6 +5286,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-code-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-code-context/-/parse-code-context-1.0.0.tgz#718c295c593d0d19a37f898473268cc75e98de1e"
+  integrity sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -5392,6 +5430,20 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-plugin-solidity@^1.0.0-alpha.55:
+  version "1.0.0-alpha.55"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.55.tgz#0842802dd655ada2ce8c2dab20aabd6addd5ee00"
+  integrity sha512-6B5wNRLu2iguuSz5POpBN9gRlaJPbmZjA/JGSjpwEQ4QPbY0/+fAmV1Qlrjj/xyDC37kx0khaTrQK46jH37+wg==
+  dependencies:
+    "@solidity-parser/parser" "^0.6.2"
+    dir-to-object "^2.0.0"
+    emoji-regex "^9.0.0"
+    escape-string-regexp "^4.0.0"
+    extract-comments "^1.1.0"
+    prettier "^2.0.5"
+    semver "^7.3.2"
+    string-width "^4.2.0"
 
 prettier@^1.14.3:
   version "1.19.1"
@@ -6002,13 +6054,15 @@ solc@0.6.8:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solhint@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-2.3.1.tgz#6fee8fc2635112bf5812f7cba8359c14e9d9a491"
-  integrity sha512-wP/G+Dqj8LNWlCI9Mt6XiQRWQfZwv1rkZe/V+HKtip5SAZJVvp144PdH28KE45ZvR99Hhrp/Mujt74fSmXsFiw==
+solhint@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.1.0.tgz#50d58c9af921a01350164350144a9809d5ec2975"
+  integrity sha512-Cc0wqKzg0NviDF7H5zsrGJ/hVwwkGqi0Hkc3YtedTev4alkJv4YADdJg4y586MpfEvMX4QPp7LugsmJzoeChkQ==
   dependencies:
+    "@solidity-parser/parser" "^0.6.0"
     ajv "^6.6.1"
     antlr4 "4.7.1"
+    ast-parents "0.0.1"
     chalk "^2.4.2"
     commander "2.18.0"
     cosmiconfig "^5.0.7"


### PR DESCRIPTION
@SeanJCasey This uses the latest version of solhint which works much better with prettier than the version coming with buidler (outdated).

I ran the prettier formatter on all the contracts and fixed 2 comment-positioning errors in SharesRequester and ValueInterpreter (comments between if/else statement brackets).

Solhint then only reported errors regarding the used pragma statements which I changed to 0.6.8 in some of the dependencies where it was set to an earlier version.

Now, solhint does not report any errors anymore (just warnings) so I also added it to .travis.yml. Warnings will still allow the build to pass but if any new errors are introduced it wont.

Please check the formatting of the contracts with prettier and if you feel like we should try to configure it differently to match our style better (there are only very limited options to do so though). 