### PR TITLE
chore: fix solhint warnings and disallow future warnings

### DIFF
--- a/contracts/factory/FundFactory.sol
+++ b/contracts/factory/FundFactory.sol
@@ -61,8 +61,8 @@ contract FundFactory is AmguConsumer {
         address _policyManagerFactory,
         address _registry
     )
-        AmguConsumer(_registry)
         public
+        AmguConsumer(_registry)
     {
         feeManagerFactory = IFeeManagerFactory(_feeManagerFactory);
         sharesFactory = ISharesFactory(_sharesFactory);

--- a/contracts/fund/fees/FeeManager.sol
+++ b/contracts/fund/fees/FeeManager.sol
@@ -31,8 +31,8 @@ contract FeeManager is IFeeManager, DSMath, Spoke {
         uint[] memory _rates,
         uint[] memory _periods
     )
-        Spoke(_hub)
         public
+        Spoke(_hub)
     {
         for (uint i = 0; i < _fees.length; i++) {
             require(

--- a/contracts/fund/fees/ManagementFee.sol
+++ b/contracts/fund/fees/ManagementFee.sol
@@ -29,7 +29,7 @@ contract ManagementFee is DSMath {
         return feeInShares;
     }
 
-    function initializeForUser(uint feeRate, uint feePeriod, address denominationAsset) external {
+    function initializeForUser(uint feeRate, uint, address) external {
         require(lastPayoutTime[msg.sender] == 0);
         managementFeeRate[msg.sender] = feeRate;
         lastPayoutTime[msg.sender] = block.timestamp;

--- a/contracts/fund/policies/utils/AddressListPolicyMixin.sol
+++ b/contracts/fund/policies/utils/AddressListPolicyMixin.sol
@@ -13,7 +13,7 @@ abstract contract AddressListPolicyMixin {
 
     event AddressesRemoved(address policyManager, address[] items);
 
-    mapping (address => EnumerableSet.AddressSet) policyManagerToList;
+    mapping (address => EnumerableSet.AddressSet) private policyManagerToList;
 
     // EXTERNAL FUNCTIONS
 

--- a/contracts/prices/ValueInterpreter.sol
+++ b/contracts/prices/ValueInterpreter.sol
@@ -12,7 +12,7 @@ import "../registry/IRegistry.sol";
 /// @author Melon Council DAO <security@meloncoucil.io>
 /// @notice Interprets price sources to yield values across asset pairs
 contract ValueInterpreter is IValueInterpreter, DSMath {
-    address REGISTRY;
+    address public REGISTRY;
 
     constructor(address _registry) public {
         REGISTRY = _registry;

--- a/contracts/registry/Registry.sol
+++ b/contracts/registry/Registry.sol
@@ -14,7 +14,7 @@ import "./utils/MelonCouncilOwnable.sol";
 /// infrastructural contracts
 /// @dev This contract should be kept relatively abstract,
 /// so that it requires minimal changes as the protocol evolves
-contract Registry is MelonCouncilOwnable {
+contract Registry is MelonCouncilOwnable { // solhint-disable-line max-states-count
     using EnumerableSet for EnumerableSet.AddressSet;
 
     event PrimitiveAdded (address primitive);

--- a/contracts/requests/SharesRequestor.sol
+++ b/contracts/requests/SharesRequestor.sol
@@ -215,6 +215,8 @@ contract SharesRequestor is DSMath, TokenUser, AmguConsumer, FundRouterMixin {
                 timestamp: block.timestamp,
                 incentiveFee: REGISTRY.incentive()
             });
+
+            // solhint-disable-next-line reentrancy
             ownerToRequestByFund[msg.sender][_hub] = request;
             __safeTransferFrom(denominationAsset, msg.sender, address(this), _investmentAmount);
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --write \"{tests,contracts}/{*,**/*}.{sol,ts}\"",
     "lint": "yarn lint:prettier && yarn lint:solhint",
     "lint:prettier": "prettier --list-different \"{tests,contracts}/{*,**/*}.{sol,ts}\"",
-    "lint:solhint": "solhint \"tests/**/*.sol\" \"contracts/**/*.sol\"",
+    "lint:solhint": "solhint --max-warnings 0 \"tests/**/*.sol\" \"contracts/**/*.sol\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/tests/contracts/PreminedToken.sol
+++ b/tests/contracts/PreminedToken.sol
@@ -8,7 +8,7 @@ contract PreminedToken is ERC20 {
       string memory _name,
       string memory _symbol,
       uint8 _decimals
-    ) ERC20(_name, _symbol) public {
+    ) public ERC20(_name, _symbol) {
         _setupDecimals(_decimals);
         _mint(msg.sender, 1000000 * 10 ** uint256(_decimals));
     }


### PR DESCRIPTION
This fixes all the warnings we have left currently.

Note the `solhint-disable-line` statements for non-issues e.g. the reentrancy one in SharesRequestor which is incorrectly flagging that line because of `msg.sender.transfer` in a different code branch (if/else statement above so not relevant)

I've also set `max-warnings` to 0 so that it will fail from now on if new warnings are introduced.