### PR TITLE
fix: Makefile error :79 [unexpected token] fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(ARTIFACTS_DIR)/: Makefile $(shell find $(CONTRACTS_DIR) -type f -name "*.sol")
 > $(FORGE) build --sizes --extra-output-files abi
 > touch $@
 
-$(INTERFACES_DIR)/: Makefile $(INTERFACES_FILE) $(ARTIFACTS_DIR)/
+$(INTERFACES_DIR): Makefile $(INTERFACES_FILE) $(ARTIFACTS_DIR)/
 > mkdir -p $(@D)
 >
 > # Remove all existing interfaces and abis.


### PR DESCRIPTION
This line fixes the `make build` error for me in a Command prompt:

**OS:** _Windows 11_

```bash
Generating interfaces ...
)nvalid line format in tests/interfaces/interfaces.txt (
make: *** [Makefile:79: tests/interfaces/internal/] Error 1
```