### PR TITLE
fix: typo 'FeeManger' -> 'FeeManager' in error message

### DIFF
--- a/contracts/release/extensions/fee-manager/fees/utils/FeeBase.sol
+++ b/contracts/release/extensions/fee-manager/fees/utils/FeeBase.sol
@@ -21,7 +21,7 @@ abstract contract FeeBase is IFee {
     address internal immutable FEE_MANAGER;
 
     modifier onlyFeeManager() {
-        require(msg.sender == FEE_MANAGER, "Only the FeeManger can make this call");
+        require(msg.sender == FEE_MANAGER, "Only the FeeManager can make this call");
         _;
     }
 


### PR DESCRIPTION
## Fixed: 

"Only the FeeManger can make this call" → "Only the FeeManager can make this call"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor text fix to improve error clarity.
> 
> - Update `require` message in `FeeBase.onlyFeeManager` from "Only the FeeManger can make this call" to "Only the FeeManager can make this call"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2375c5948b76cde6913cf6b2256dcfc4a34bf82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->